### PR TITLE
Reducing left margin for sidebar

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -36,7 +36,6 @@
   }
 
   @include mq(lg) {
-    width: calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width});
     min-width: $nav-width;
   }
 }
@@ -108,7 +107,6 @@
   width: 100%;
 
   @include mq(lg) {
-    width: $nav-width + 32px;
   }
 }
 


### PR DESCRIPTION
Solves #76 

Reduced the left margin/padding for the side navigation bar to make more space for central content.

**Screenshots**

**Before**

![image](https://user-images.githubusercontent.com/47032027/68929108-a362fa00-07b1-11ea-813c-8783505ea353.png)

![image](https://user-images.githubusercontent.com/47032027/68929119-a827ae00-07b1-11ea-808c-05e3940259c8.png)

**After**

![image](https://user-images.githubusercontent.com/47032027/68929125-aeb62580-07b1-11ea-8e8d-f6a40fef2506.png)

![image](https://user-images.githubusercontent.com/47032027/68929127-b1b11600-07b1-11ea-8991-44ff4fb9159b.png)
