### PR TITLE
[GCI] Fix text overflow

### DIFF
--- a/_includes/binary.html
+++ b/_includes/binary.html
@@ -14,7 +14,7 @@
 <style>
     #binary			{width: 100%;}
     #decimal1		{font-family: Arial, Helvetica, sans-serif; float: left; font-size: 5vw; width: 21vw; margin: 2.7vw 0 0; float: left}
-    .column			{font-family: Arial, Helvetica, sans-serif; float: left; text-align: center; width: 54px}
+    .column			{font-family: Arial, Helvetica, sans-serif; float: left; text-align: center; width: fit-content}
     .column_heading	{font-size: 1.6vw; color: #666666}
     .bit			{font-size: 5vw; background-color: #FFFFFF; color:#000000; border-radius: 1.3vw; margin: 0.25vw; border: 1px solid grey}
 


### PR DESCRIPTION
Closes #25 

Fixed text overflow in binary demo using CSS width: fit-content.

This is a GCI task