### PR TITLE
Fixed sidebar width for large screens

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -36,7 +36,7 @@
   }
 
   @include mq(lg) {
-    width: calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width});
+    width: calc((100% - #{$nav-width + $content-width}) / 4 + #{$nav-width});
     min-width: $nav-width;
   }
 }
@@ -70,7 +70,7 @@
 
   @include mq(lg) {
     padding-left: $gutter-spacing;
-    margin-left: calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width});
+    margin-left: calc((100% - #{$nav-width + $content-width}) / 4 + #{$nav-width});
   }
 }
 


### PR DESCRIPTION
Changed the sidebar width for large screens to be the same as medium screens so that it isn't too wide.
Issue: https://github.com/CircuitVerse/Interactive-Book/issues/76
**New commit:** The sidebar width is not fixed but now increases _twice_ (typo in commit message) as slowly for large screens so as to not take up an unnecessary amount of space. 
Before: 
<img width="960" alt="before" src="https://user-images.githubusercontent.com/50021387/70059675-3354d080-1607-11ea-9fb6-421099c74cb3.png">
After (On large/wide screens):
![image](https://user-images.githubusercontent.com/50021387/70152208-d0307000-16d2-11ea-992c-b856364a3904.png)

Mobile and tablet view stay the same:
![image](https://user-images.githubusercontent.com/50021387/70152057-83e53000-16d2-11ea-8c0b-291111f6948b.png)
![image](https://user-images.githubusercontent.com/50021387/70152079-92cbe280-16d2-11ea-8d8c-dc80b394c3ff.png)

