### PR TITLE
Make the table generated by "Truth Table Generator" responsive

### DIFF
--- a/_includes/truth_table.html
+++ b/_includes/truth_table.html
@@ -16,7 +16,7 @@
     <br>
     <!-- Output -->
     <div class="align-center container">
-        <div id="table-placeholder" style="overflow-x:auto"></div>
+        <div id="table-placeholder" style="overflow-x:auto;overflow-y:auto"></div>
     </div>
 </main>
 
@@ -26,7 +26,6 @@
         font-family: Roboto, sans-serif;
         font-style: normal;
         text-transform: none;
-        font-weight: normal;
         font-variant: normal;
     }
 

--- a/_includes/truth_table.html
+++ b/_includes/truth_table.html
@@ -16,7 +16,7 @@
     <br>
     <!-- Output -->
     <div class="align-center container">
-        <div id="table-placeholder"></div>
+        <div id="table-placeholder" style="overflow-x:auto"></div>
     </div>
 </main>
 


### PR DESCRIPTION
This is my submission to the GCI task for this issue. My username on the GCI site is Bubble Sort. This is the new functionality:

![image](https://user-images.githubusercontent.com/11043701/70861312-f4d2e600-1f23-11ea-85fd-d2628c7b5535.png)

Resolves #94