### PR TITLE
Element made visible after shrinking page less than 850px

### DIFF
--- a/_includes/gates.html
+++ b/_includes/gates.html
@@ -14,7 +14,7 @@
 #clipboard img	{padding: 2px; float:none}
 
 @media screen and (max-width: 849px) {
-    #clipboard	{display: none}
+.clipboard_div {padding-top: 10%;margin: 5%;}
 }
 @media screen and (max-width: 499px) {
     p			{display: none}
@@ -114,7 +114,7 @@ function disableSelection(target)
 <img src="../assets/images/NOR_gate.png" alt="NOR" class="tile">
 <img src="../assets/images/EOR_gate.png" alt="EOR" class="tile">
 <img src="../assets/images/XNOR_gate.png" alt="NXOR" class="tile">
-<div id="clipboard"></div>
+<div class="clipboard_div"><div id="clipboard"></div></div>
 <p style="clear:left">You can also click/tap a symbol to copy it and then click/tap to paste it into the box. </p>
 <div style="display: inline-block">
     <div class="circuit">


### PR DESCRIPTION
**Issue resolved** #72  

**Before:** Clipboard element missing

![2020-01-02 (1)](https://user-images.githubusercontent.com/58560983/71674905-9078a900-2da2-11ea-8d8c-ade2e124a8d6.png)

**After:** Clipboard element visible

![2020-01-02](https://user-images.githubusercontent.com/58560983/71674711-fca6dd00-2da1-11ea-9e4a-77c0bfbbb09c.png)

**Full screen:**

![2020-01-02 (2)](https://user-images.githubusercontent.com/58560983/71675127-201e5780-2da3-11ea-9625-6da320157fb0.png)
