### PR TITLE
[GCI] Add universal gates section

### DIFF
--- a/docs/universal_gates.md
+++ b/docs/universal_gates.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Universal Gates
+comments: true
+nav_order: 3
+---
+# Universal Gates
+{: .no_toc }
+
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Introduction
+
+Universal gates are gates which can be used to implement all other gates.
+This is useful as manufacturers only need to produce 1 type of universal gate to be able to use all other gates.
+
+The universal gates are NOR and NAND.
+This page will show you how to implement AND, OR and NOT gates using universal gates.
+The AND, OR and NOT gates are basic gates that are commonly used and are very important.
+
+## NOR gate
+The NOR gate is the opposite of the OR gate. It is like an OR gate followed by a NOT gate.
+
+### Implementing NOT gate
+A NOT gate can be implemented by passing the same input into both inputs of the NOR gate.
+<iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/45175" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
+
+### Implementing OR gate
+An OR gate can be implemented by passing the output of NOR to the NOT gate we implemented earlier.
+<iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/45176" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
+
+### Implementing AND gate
+Since the NOR gate outputs true only when both inputs are 0, an AND gate can be implemented by inverting the inputs to a NOR gate.
+<iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/45177" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
+
+## NAND gate
+The NAND gate is the opposite of the AND gate. It is like an AND gate followed by a NOT gate.
+
+### Implementing NOT gate
+Similarly to NOR, a NOT gate can also be implemented by joining the inputs of a NAND gate.
+<iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/45178" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
+
+### Implementing OR gate
+The only time the NAND gate output is 0 is when both inputs are 1. Therefore, by inverting the inputs of a NAND gate, an OR gate can be implemented.
+<iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/45179" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
+
+### Implementing AND gate
+The AND gate is simply the output of a NAND gate inverted.
+<iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/45180" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
+
+
+{% include disqus.html %}


### PR DESCRIPTION
Fixes #27 

Added section on Universal gates and demonstrate how to implement NOT, OR and AND gates with each universal gate.

# Screenshot of Introduction
![image](https://user-images.githubusercontent.com/26194273/71762875-372e8800-2f10-11ea-9c4a-61055f3bae31.png)

# Screenshot of implementing NOT and OR gate with NOR
![image](https://user-images.githubusercontent.com/26194273/71762885-5f1deb80-2f10-11ea-8f52-eca83b20b96e.png)

# Screenshot of implementing AND gate with NOR
![image](https://user-images.githubusercontent.com/26194273/71762891-78269c80-2f10-11ea-8231-8935c79b92ce.png)

# Screenshot of NOT and OR gate with NAND
![image](https://user-images.githubusercontent.com/26194273/71762898-92f91100-2f10-11ea-8ef4-69df076c4595.png)

# Screenshot of AND gate with NAND
![image](https://user-images.githubusercontent.com/26194273/71762901-a1472d00-2f10-11ea-8713-7e3475746dfc.png)


# Implementations embedded
## NOR gate
[not](https://circuitverse.org/users/11772/projects/45175)  
[or](https://circuitverse.org/users/11772/projects/45176)
[and](https://circuitverse.org/users/11772/projects/45177)

## NAND gate
[not](https://circuitverse.org/users/11772/projects/45178)
[or](https://circuitverse.org/users/11772/projects/45179)
[and](https://circuitverse.org/users/11772/projects/45180)


[GCI task](https://codein.withgoogle.com/dashboard/task-instances/5517828283695104/)

Please review @deepak2431 @sakshi1499
