### PR TITLE
Fix Flip Flop state table

### DIFF
--- a/_includes/flipflop2.html
+++ b/_includes/flipflop2.html
@@ -189,6 +189,13 @@
 								flipflops['K' + alph] = "";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='J" + alph + "' placeholder='J" + alph + "' required>&nbsp;";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='K" + alph + "' placeholder='K" + alph + "' required>&nbsp;";
+						        if(flipflopCount === 2)
+							  if (i === 0)
+								$("#step2").append("<strong>Hints</strong>: <br>Next state input for J (JA) = B .<br>Next state input for K (KA) = y'*B");
+							  else if (i === 1)
+								$("#step2").append("<br>Next state input for J (JB) = y' .<br>Next state input for K (KB) = y'*A + A'*y");
+							if (flipflopCount === 1)
+								$("#step2").append("<strong>Hints</strong>: <br>Next state input for J (JA) = y <br>Next state input for K (KA) = y'*A");
 							}
 						} else if (input['flipflop'] == "RS") {
 							for (var i = 0; i < functionCount; i++) {
@@ -209,12 +216,24 @@
 								var alph = String.fromCharCode(65 + i);
 								flipflops['T' + alph] = "";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='T" + alph + "' placeholder='T" + alph + "' required>&nbsp;";
+							  if (flipflopCount === 2) 
+							    if (i === 0) 	      
+								$("#step2").append("<strong>Hints</strong>: <br>Next state input for T (TA) = y");
+							    else if (i === 1)
+							        $("#step2").append("<br>Next state input for T (TB) = y*A");
+							  if (flipflopCount === 1)
+								$("#step2").append("<strong>Hints</strong>: <br>Next state input for T (TA) = y");
 							}
 						}
 
 						if (input['output'] == "o1") {
 							outputCount = 1;
 							ioFunctions += "<input type='text' style='width:150px' class='form-control' id='Z' placeholder='Z ( Output )' required>&nbsp;";
+						 if(flipflopCount === 2)  
+						   if(input['flipflop'] == "JK")
+				                         $("#step2").append("<br>Output (Z) = y'*A + A'*y");
+						   else if(input['flipflop'] == "T")
+          	                                         $("#step2").append("<br>Output (Z) = A*B");
 						}
 
 						$('#step2 p.form-inline').append(ioFunctions);

--- a/_includes/flipflop2.html
+++ b/_includes/flipflop2.html
@@ -189,12 +189,12 @@
 								flipflops['K' + alph] = "";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='J" + alph + "' placeholder='J" + alph + "' required>&nbsp;";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='K" + alph + "' placeholder='K" + alph + "' required>&nbsp;";
-						        if(flipflopCount === 2)
-							  if (i === 0)
+						          if(flipflopCount === 2)
+							    if (i === 0)
 								$("#step2").append("<strong>Hints</strong>: <br>Next state input for J (JA) = B .<br>Next state input for K (KA) = y'*B");
-							  else if (i === 1)
-								$("#step2").append("<br>Next state input for J (JB) = y' .<br>Next state input for K (KB) = y'*A + A'*y");
-							if (flipflopCount === 1)
+							    else if (i === 1)
+							 	$("#step2").append("<br>Next state input for J (JB) = y' .<br>Next state input for K (KB) = y'*A + A'*y");
+							  if (flipflopCount === 1)
 								$("#step2").append("<strong>Hints</strong>: <br>Next state input for J (JA) = y <br>Next state input for K (KA) = y'*A");
 							}
 						} else if (input['flipflop'] == "RS") {
@@ -204,13 +204,22 @@
 								flipflops['R' + alph] = "";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='S" + alph + "' placeholder='R" + alph + "' required>&nbsp;";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='R" + alph + "' placeholder='S" + alph + "' required>&nbsp;";
+							  if (flipflopCount === 1)
+						                $("#step2").append("<strong>Hints</strong>: <br>Next state input for S (SA) = x <br>Next state input for R (RA) = y");
 							}
 						} else if (input['flipflop'] == "D") {
 							for (var i = 0; i < functionCount; i++) {
 								var alph = String.fromCharCode(65 + i);
 								flipflops['D' + alph] = "";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='D" + alph + "' placeholder='D" + alph + "' required>&nbsp;";
-							}
+					                   if(flipflopCount === 2)
+							     if (i === 0)
+								$("#step2").append("<strong>Hints</strong>: <br>Next state input for D (DA) = y*A + y*B");
+							     else if (i === 1)
+							 	$("#step2").append("<br>Next state input for D (DB) = y*A'");
+							   if(flipflopCount === 1)
+								$("#step2").append("<strong>Hints</strong>: <br>Next state input for D (DA) = y");
+							}	
 						} else {
 							for (var i = 0; i < functionCount; i++) {
 								var alph = String.fromCharCode(65 + i);
@@ -234,6 +243,8 @@
 				                         $("#step2").append("<br>Output (Z) = y'*A + A'*y");
 						   else if(input['flipflop'] == "T")
           	                                         $("#step2").append("<br>Output (Z) = A*B");
+					           else if(input['flipflop'] == "D")
+				                         $("#step2").append("<br>Output (Z) = y'*A + y'*B");
 						}
 
 						$('#step2 p.form-inline').append(ioFunctions);

--- a/_includes/flipflop2.html
+++ b/_includes/flipflop2.html
@@ -205,6 +205,7 @@
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='S" + alph + "' placeholder='R" + alph + "' required>&nbsp;";
 								ioFunctions += "<input type='text' style='width:150px' class='form-control' id='R" + alph + "' placeholder='S" + alph + "' required>&nbsp;";
 							  if (flipflopCount === 1)
+							     if(inputCount === 2)
 						                $("#step2").append("<strong>Hints</strong>: <br>Next state input for S (SA) = x <br>Next state input for R (RA) = y");
 							}
 						} else if (input['flipflop'] == "D") {

--- a/assets/js/flipflop.js
+++ b/assets/js/flipflop.js
@@ -197,7 +197,7 @@ function evaluateFunction(rowCount, inputs, booleanFunction) {
 				}
 			} else if (token == '\'') {
 				temp1 = stack.pop();
-				stack.push(!temp1 | 0);
+				stack.push(1-temp1);
 
 			} else if (token == '*') {
 				temp1 = stack.pop();

--- a/assets/js/flipflop.js
+++ b/assets/js/flipflop.js
@@ -68,7 +68,7 @@ function generateStateTable(flipflopCount, inputCount, booleanFunctions, flipflo
 
 	for(var i = 0; i < nextStates.length; i++) {
 		stateTable.push({
-			col : nextStates[i].col,
+			col : nextStates[i].col + "*",
 			row : nextStates[i].row
 		});
 	}
@@ -97,7 +97,7 @@ function evaluateFlipflop(flipflop, ff, state) {
 				nextState += 1;
 			}
 			else if(ff[0].charAt(i) == '1' && ff[1].charAt(i) == '1'){
-				nextState += !digit | 0;
+				nextState += (1-digit);
 			}
 			else{
 				nextState += digit;
@@ -138,7 +138,7 @@ function evaluateFlipflop(flipflop, ff, state) {
 				nextState += digit;
 			}
 			else if(ff[0].charAt(i) == '1'){
-				nextState += !digit | 0;
+				nextState += (1-digit);
 			}
 		}
 	}
@@ -202,13 +202,13 @@ function evaluateFunction(rowCount, inputs, booleanFunction) {
 			} else if (token == '*') {
 				temp1 = stack.pop();
 				temp2 = stack.pop();
-				console.log(temp1 + '||' + temp2 + "=" + temp1 || temp2);
-				stack.push(temp1 || temp2);
+				console.log(temp1 + '&&' + temp2 + "=" + temp1 && temp2);
+				stack.push(temp1 && temp2);
 			} else if (token == '+') {
 				temp1 = stack.pop();
 				temp2 = stack.pop();
-				console.log(temp1 + "&&" + temp2 + "=" + temp1 && temp2);
-				stack.push(temp1 && temp2);
+				console.log(temp1 + "||" + temp2 + "=" + temp1 || temp2);
+				stack.push(temp1 || temp2);
 			}
 			console.log(stack);
 		}


### PR DESCRIPTION
[GCI TASK](https://codein.withgoogle.com/dashboard/task-instances/6517009274109952/)
Fixes https://github.com/CircuitVerse/Interactive-Book/issues/142
Preview: https://deploy-preview-181--tender-ardinghelli-ebb79f.netlify.com/docs/flipflop2.html

## Description 
- Both T flipflop and JK flipflop works now.
- The flip flop state table gives correct results now.

## Screenshot 
### Example: State table of T Flip Flop
The next state of T Flip flop should be decided by the following :
- When TA is 0 the next state should be equal to the input of Flip flop.
- When TA is 1 the next state should be the negation of the input of the Flip flop.

The operation of OR and AND operations was the opposite.
Made some changes regarding the above.

![Screenshot (160)](https://user-images.githubusercontent.com/35162705/72025344-d4d1e080-329d-11ea-9cf4-56a80c42d57c.png)
![Screenshot (161)](https://user-images.githubusercontent.com/35162705/72025347-d6030d80-329d-11ea-878f-00aa1edf2696.png)
![Screenshot (162)](https://user-images.githubusercontent.com/35162705/72025353-da2f2b00-329d-11ea-9f64-ec5eaebfbc11.png)
![Screenshot (163)](https://user-images.githubusercontent.com/35162705/72025416-0fd41400-329e-11ea-98b0-0390e75b5345.png)

### Example: State table of JK Flip Flop
- There was a similar problem with JK Flip Flop.

![Screenshot (164)](https://user-images.githubusercontent.com/35162705/72177922-c69fd380-3407-11ea-9b88-783d07268e9f.png)
![Screenshot (176)](https://user-images.githubusercontent.com/35162705/72198283-633a9380-3451-11ea-85c8-5e001edbeec5.png)
![Screenshot (177)](https://user-images.githubusercontent.com/35162705/72198282-5f0e7600-3451-11ea-9323-0bc23f87b058.png)
![Screenshot (175)](https://user-images.githubusercontent.com/35162705/72184789-3d909880-3417-11ea-96ca-43dc59b8ce46.png)