### PR TITLE
FixedDarked mode CSS 

### DIFF
--- a/_includes/truth_table.html
+++ b/_includes/truth_table.html
@@ -1,8 +1,8 @@
 <main id="main">
     <!-- Input -->
     <div class="align-center container">
-        <h1>Truth Table Generator</h1>
-        <p>Enter your boolean logic expression in the following format:<br>
+        <h1> class ="truth-table">Truth Table Generator</h1>
+        <p>class ="truth-table>Enter your boolean logic expression in the following format<br>
             AND = <span class="example">AB</span>&emsp;
             OR = <span class="example">A+B</span>&emsp;
             NOT = <span class="example">A'</span><br>
@@ -34,7 +34,7 @@
         padding: 50px;
     }
 
-    h1 {
+    .truth-table h1 {
         color: black;
         margin: 0;
     }
@@ -51,7 +51,7 @@
         max-width: 100%;
     }
 
-    p {
+    .truth-table p {
         color: #444;
         font-size: 16px;
         line-height: 24px;

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -108,3 +108,15 @@ hr {
   background-color: $border-color;
   border: 0;
 }
+select, option {
+  color: black;
+}
+
+input {
+   color: black;
+ }
+
+ .breadcrumb-nav-list {
+   margin-left:100px;
+   margin-top: -20px;
+ } 

--- a/docs/application.md
+++ b/docs/application.md
@@ -4,6 +4,7 @@ title:  Application of Shift Registers
 comments: true
 nav_order: 15
 ---
+# Application of Shift Registers
 
 In previous module, we discussed four types of shift registers. Based on the requirement, we can use one of those shift registers. Following are the applications of shift registers.
 

--- a/docs/kmapi.md
+++ b/docs/kmapi.md
@@ -1,5 +1,5 @@
 ---
-layout: kmap
+layout: default
 title: Interactive Karnaugh Map
 comments: true
 nav_order: 7


### PR DESCRIPTION
Fixed #7 
https://github.com/CircuitVerse/Interactive-Book/issues/7 

**1. Added header for Application of Shift Registers**

- Before:
<img width="1111" alt="Screen Shot 2020-01-14 at 12 36 47 AM" src="https://user-images.githubusercontent.com/44331935/72407459-73ce6080-3714-11ea-8675-4107f9de8229.png">


- After: 
<img width="1018" alt="Screen Shot 2020-01-14 at 12 35 39 AM" src="https://user-images.githubusercontent.com/44331935/72407357-2ce06b00-3714-11ea-9358-dfb2932cc8a5.png">



**2. Moved sub-header to the right of slide bar**

- Before:
<img width="1044" alt="Screen Shot 2020-01-14 at 12 37 00 AM" src="https://user-images.githubusercontent.com/44331935/72407460-77fa7e00-3714-11ea-972c-5f39154c6658.png">


- After:
<img width="906" alt="Screen Shot 2020-01-14 at 12 34 27 AM" src="https://user-images.githubusercontent.com/44331935/72407439-67e29e80-3714-11ea-8a1c-2f1534804f2a.png">


**3.Changed text color so Boolean function is visible in dark mode**

- Before:
<img width="1093" alt="Screen Shot 2020-01-14 at 12 36 38 AM" src="https://user-images.githubusercontent.com/44331935/72407417-5ac5af80-3714-11ea-9a49-b0da03200f92.png">


- After:
<img width="949" alt="Screen Shot 2020-01-14 at 12 34 51 AM" src="https://user-images.githubusercontent.com/44331935/72407343-1f2ae580-3714-11ea-92be-780324dca9a9.png">

**4.Added slide bar for Interactive Karnaugh Map**

- Before:
<img width="971" alt="Screen Shot 2020-01-14 at 12 36 28 AM" src="https://user-images.githubusercontent.com/44331935/72407402-513c4780-3714-11ea-8009-b0d3a61087da.png">

- After:
<img width="994" alt="Screen Shot 2020-01-14 at 12 36 14 AM" src="https://user-images.githubusercontent.com/44331935/72407387-42ee2b80-3714-11ea-9c28-aba5f03c9e5e.png">

