### PR TITLE
Fix dark mode css

### DIFF
--- a/_includes/truth_table.html
+++ b/_includes/truth_table.html
@@ -1,8 +1,8 @@
 <main id="main">
     <!-- Input -->
     <div class="align-center container">
-        <h1>Truth Table Generator</h1>
-        <p>Enter your boolean logic expression in the following format:<br>
+        <h1> class ="truth-table">Truth Table Generator</h1>
+        <p>class ="truth-table>Enter your boolean logic expression in the following format<br>
             AND = <span class="example">AB</span>&emsp;
             OR = <span class="example">A+B</span>&emsp;
             NOT = <span class="example">A'</span><br>
@@ -34,7 +34,7 @@
         padding: 50px;
     }
 
-    h1 {
+    .truth-table h1 {
         color: black;
         margin: 0;
     }
@@ -51,7 +51,7 @@
         max-width: 100%;
     }
 
-    p {
+    .truth-table p {
         color: #444;
         font-size: 16px;
         line-height: 24px;

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -108,3 +108,15 @@ hr {
   background-color: $border-color;
   border: 0;
 }
+select, option {
+  color: black;
+}
+
+input {
+   color: black;
+ }
+
+ .breadcrumb-nav-list {
+   margin-left:100px;
+   margin-top: -20px;
+ } 

--- a/docs/application.md
+++ b/docs/application.md
@@ -4,6 +4,7 @@ title:  Application of Shift Registers
 comments: true
 nav_order: 15
 ---
+# Application of Shift Registers
 
 In previous module, we discussed four types of shift registers. Based on the requirement, we can use one of those shift registers. Following are the applications of shift registers.
 

--- a/docs/kmapi.md
+++ b/docs/kmapi.md
@@ -1,5 +1,5 @@
 ---
-layout: kmap
+layout: default
 title: Interactive Karnaugh Map
 comments: true
 nav_order: 7

--- a/docs/kmapi.md
+++ b/docs/kmapi.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: kmap
 title: Interactive Karnaugh Map
 comments: true
 nav_order: 7


### PR DESCRIPTION
Fixed #7 

**1. Added header for Application of Shift Registers**

Before:
<img width="1111" alt="Screen Shot 2020-01-14 at 12 36 47 AM" src="https://user-images.githubusercontent.com/44331935/72493700-8a3cf080-37d6-11ea-9a5e-02acfe6fa996.png">

After:
<img width="949" alt="Screen Shot 2020-01-14 at 12 34 51 AM" src="https://user-images.githubusercontent.com/44331935/72493706-8f01a480-37d6-11ea-8525-f246e1093b93.png">

**2. Moved sub-header to the right of slide bar**
Before:
<img width="1044" alt="Screen Shot 2020-01-14 at 12 37 00 AM" src="https://user-images.githubusercontent.com/44331935/72493802-d425d680-37d6-11ea-8099-d431e044e421.png">


After:
<img width="906" alt="Screen Shot 2020-01-14 at 12 34 27 AM" src="https://user-images.githubusercontent.com/44331935/72493784-ca03d800-37d6-11ea-9278-96c306070509.png">



**3.Changed text color so Boolean function is visible in dark mode**
Before:
<img width="1093" alt="Screen Shot 2020-01-14 at 12 36 38 AM" src="https://user-images.githubusercontent.com/44331935/72493772-bbb5bc00-37d6-11ea-9467-7eafbbd1a4da.png">


After:
<img width="1018" alt="Screen Shot 2020-01-14 at 12 35 39 AM" src="https://user-images.githubusercontent.com/44331935/72493768-b9ebf880-37d6-11ea-9826-c43226e7f30a.png">


