### PR TITLE
Fix dark mode css2

### DIFF
--- a/_includes/truth_table.html
+++ b/_includes/truth_table.html
@@ -1,8 +1,8 @@
 <main id="main">
     <!-- Input -->
     <div class="align-center container">
-        <h1>Truth Table Generator</h1>
-        <p>Enter your boolean logic expression in the following format:<br>
+        <h1> class ="truth-table">Truth Table Generator</h1>
+        <p>class ="truth-table>Enter your boolean logic expression in the following format<br>
             AND = <span class="example">AB</span>&emsp;
             OR = <span class="example">A+B</span>&emsp;
             NOT = <span class="example">A'</span><br>
@@ -34,7 +34,7 @@
         padding: 50px;
     }
 
-    h1 {
+    .truth-table h1 {
         color: black;
         margin: 0;
     }
@@ -51,7 +51,7 @@
         max-width: 100%;
     }
 
-    p {
+    .truth-table p {
         color: #444;
         font-size: 16px;
         line-height: 24px;

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -108,3 +108,15 @@ hr {
   background-color: $border-color;
   border: 0;
 }
+select, option {
+  color: black;
+}
+
+input {
+   color: black;
+ }
+
+ .breadcrumb-nav-list {
+   margin-left:100px;
+   margin-top: -20px;
+ } 

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -108,15 +108,16 @@ hr {
   background-color: $border-color;
   border: 0;
 }
+
 select, option {
-  color: black;
+  color: #000000;
 }
 
 input {
-   color: black;
+  color: #000000;
  }
 
- .breadcrumb-nav-list {
-   margin-left:100px;
+.breadcrumb-nav-list {
+   margin-left: 100px;
    margin-top: -20px;
- } 
+ }

--- a/docs/application.md
+++ b/docs/application.md
@@ -4,6 +4,7 @@ title:  Application of Shift Registers
 comments: true
 nav_order: 15
 ---
+# Application of Shift Registers
 
 In previous module, we discussed four types of shift registers. Based on the requirement, we can use one of those shift registers. Following are the applications of shift registers.
 

--- a/docs/kmapi.md
+++ b/docs/kmapi.md
@@ -1,5 +1,5 @@
 ---
-layout: kmap
+layout: default
 title: Interactive Karnaugh Map
 comments: true
 nav_order: 7

--- a/docs/kmapi.md
+++ b/docs/kmapi.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: kmap
 title: Interactive Karnaugh Map
 comments: true
 nav_order: 7


### PR DESCRIPTION
Fixed #7

**1. Added header for Application of Shift Registers**

Before:
![image](https://user-images.githubusercontent.com/44331935/72590248-27b92280-38b2-11ea-8e3b-dc0a0b627d65.png)

After:
![image](https://user-images.githubusercontent.com/44331935/72590288-39022f00-38b2-11ea-9e9e-b3e3b0320b93.png)


**2. Moved sub-header to the right of slide bar**
Before:
![image](https://user-images.githubusercontent.com/44331935/72590308-43242d80-38b2-11ea-9d7c-66494b5cf6ce.png)

After:
![image](https://user-images.githubusercontent.com/44331935/72590322-47e8e180-38b2-11ea-888a-41020c1cadb5.png)

**3.Changed text color so Boolean function is visible in dark mode**
Before:
![image](https://user-images.githubusercontent.com/44331935/72590367-5931ee00-38b2-11ea-896a-487c7e054e52.png)

After:
![image](https://user-images.githubusercontent.com/44331935/72590381-5f27cf00-38b2-11ea-96a3-fb618c3daa75.png)
