### PR TITLE
Remove kmap layout and instead use default layout

### DIFF
--- a/_includes/kmap.html
+++ b/_includes/kmap.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=240" />
     <script src="../assets/js/module.js"></script>
     <script language="JavaScript" type="text/javascript">
+        $(".main-content-wrap").attr('id', 'scrollcount');
         var karnaugh = -1;
         var qmc = -1;
         function run() {
@@ -35,6 +36,8 @@
     </script>
     <style type="text/css">
         .qmcMathFont{font-family:"Times New Roman",Georgia,Serif;font-size:30px}
+        #myKarnaughMap_KarnaughMap{background: #fff;}
+        #myKarnaughMap{color: grey;}
     </style>
 </head>
 <body onload="run();">


### PR DESCRIPTION
Fixes: #223 
~~and #236~~ 

The kmap layout is removed, and the default layout is used instead of it in Intractive Karnaugh Map page, and some dark-mode issues of the same page are resolved.

Before:
![2020-01-25 (3)](https://user-images.githubusercontent.com/58560983/73125642-2208be80-3fcf-11ea-9ff2-7d855bc1ac4f.png)

After:
![2020-01-25 (1)](https://user-images.githubusercontent.com/58560983/73125641-21702800-3fcf-11ea-906b-7ebf7f64f3e0.png)

Light-mode is not affected much
![2020-01-26](https://user-images.githubusercontent.com/58560983/73125733-3ac5a400-3fd0-11ea-822c-ed24a7027533.png)
