### PR TITLE
Fix the size of bullet

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -27,6 +27,8 @@
 
 .connector{
   margin-right: 5%;
+  height: 12px;
+  width: 12px;
 
 }
 

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -65,7 +65,7 @@ It is just like counting in decimal except we reach 10 much sooner.
 
 | Binary     | Explanation   |
 |:----------:|:-------------:|
-| 0          | We start a    |
+| 0          | We start at 0    |
 | 1          | Then 1        |
 | **1**0     | Now start back at 0 again, **but add 1 on the left**|
 | 11         | 1 more        |


### PR DESCRIPTION
Fix #135 
I simply changed the CSS to fix the size of bullet. It works fine in Google Chrome Version 79.0.3945.130
and Mozilla Firefox Version 72.0.2

Google Chrome:-
![Screenshot (503)](https://user-images.githubusercontent.com/43378325/73293175-67282d00-4229-11ea-87a1-00abd732948a.png)

Mozilla Firefox:-
![Screenshot (502)](https://user-images.githubusercontent.com/43378325/73293210-76a77600-4229-11ea-8b6c-7c7253650b13.png)
