### PR TITLE
Fix #59 Div configured for Dark Mode and Correct Typo

### DIFF
--- a/_includes/application1.html
+++ b/_includes/application1.html
@@ -5,7 +5,7 @@
             <input type="button" value="Send!" onClick="decode();">
         </p>
     </div>
-        <DIV id="subjects" style="width: 160px; height: 210px; border: 1px solid black; padding: 0 0 0 10px; float:left; background-color:#FFFFFF; margin-bottom: 10px"></DIV></div>
+        <DIV id="subjects" style="width: 160px; height: 210px; border: 1px solid black; padding: 0 0 0 10px; float:left; margin-bottom: 10px"></DIV></div>
 
     <p style="clear: left"></p>
 </div>

--- a/docs/application2.md
+++ b/docs/application2.md
@@ -4,7 +4,7 @@ title: Basic Applications
 comments: true
 nav_order: 4
 ---
-# Basic Apllications
+# Basic Applications
 {: .no_toc }
 
 

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -65,7 +65,7 @@ It is just like counting in decimal except we reach 10 much sooner.
 
 | Binary     | Explanation   |
 |:----------:|:-------------:|
-| 0          | We start a    |
+| 0          | We start at 0    |
 | 1          | Then 1        |
 | **1**0     | Now start back at 0 again, **but add 1 on the left**|
 | 11         | 1 more        |


### PR DESCRIPTION
Fix #59 
Changed the CSS regarding the background color of div which was fixed to White.
Corrected the Typo in Page Heading "Basic Apllications" to "Basic Applications".
Homework div-

Before:-

![Before_dark](https://user-images.githubusercontent.com/43378325/73968926-7f422f80-4940-11ea-86d7-d3ffce7a91c7.png)
After:-

![Screenshot (530)](https://user-images.githubusercontent.com/43378325/73968995-94b75980-4940-11ea-98d0-e04e2f0b1fcc.png)

Typo -

Before:-

![Screenshot (527)](https://user-images.githubusercontent.com/43378325/73968961-879a6a80-4940-11ea-86c0-78bbb18e1843.png)
After:-

![Screenshot (529)](https://user-images.githubusercontent.com/43378325/73969178-ef50b580-4940-11ea-81f6-6c63c7c0ba08.png)






