### PR TITLE
Fix #62 Text visible in Dark Mode

### DIFF
--- a/_includes/binary.html
+++ b/_includes/binary.html
@@ -15,7 +15,7 @@
     #binary			{width: 100%;}
     #decimal1		{font-family: Arial, Helvetica, sans-serif; float: left; font-size: 5vw; width: 21vw; margin: 2.7vw 0 0; float: left}
     .column			{font-family: Arial, Helvetica, sans-serif; float: left; text-align: center; width: fit-content}
-    .column_heading	{font-size: 1.6vw; color: #666666}
+    .column_heading	{font-size: 1.6vw;}
     .bit			{font-size: 5vw; background-color: #FFFFFF; color:#000000; cursor: pointer; border-radius: 1.3vw; margin: 0.25vw; border: 1px solid grey}
 
 </style>

--- a/_includes/binary2.html
+++ b/_includes/binary2.html
@@ -64,7 +64,7 @@
 <style>
     #binary			{width: 100%;}
     #decimal		{font-family: Arial, Helvetica, sans-serif; float: left; font-size: 5vw; width: 21vw; margin: 2.7vw 0 0 2vw; float: left}
-    .column_heading	{font-size: 1.6vw; color: #666666}
+    .column_heading	{font-size: 1.6vw;}
     .binary			{width: 620px; margin: auto}
     #container		{width: 560px; display: block; margin: auto; margin-bottom :30px}
     #too_big		{display: none; font-style: italic; clear: left}

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -65,7 +65,7 @@ It is just like counting in decimal except we reach 10 much sooner.
 
 | Binary     | Explanation   |
 |:----------:|:-------------:|
-| 0          | We start a    |
+| 0          | We start at 0    |
 | 1          | Then 1        |
 | **1**0     | Now start back at 0 again, **but add 1 on the left**|
 | 11         | 1 more        |


### PR DESCRIPTION
Fix #62 
Removed the color attribute in class (.column_heading) in Html pages binary.html and binary2.html was overriding the body-text-color(dark.scss) in dark mode. Works fine for light mode too.

Before:-
Binary Numbers(binary.html)-
![Screenshot (531)](https://user-images.githubusercontent.com/43378325/73977267-0ea30f00-4950-11ea-9da8-2f35e68db564.png)

Operators in Binary(binary2.html)-
![Screenshot (532)](https://user-images.githubusercontent.com/43378325/73977272-106cd280-4950-11ea-9fe9-83f8a6beb41e.png)

After:-
DarkMode-
![Screenshot (533)](https://user-images.githubusercontent.com/43378325/73977293-182c7700-4950-11ea-840c-e14029995996.png)
![Screenshot (534)](https://user-images.githubusercontent.com/43378325/73977305-1d89c180-4950-11ea-9eaf-e03be3c5d875.png)

LightMode-
![Screenshot (535)](https://user-images.githubusercontent.com/43378325/73977325-27abc000-4950-11ea-98d2-37908b3fd1b3.png)
![Screenshot (536)](https://user-images.githubusercontent.com/43378325/73977330-2a0e1a00-4950-11ea-929e-3c865aa03d2d.png)

