### PR TITLE
Fix #232 Make the operator visible in dark mode.

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -109,10 +109,6 @@ hr {
   border: 0;
 }
 
-select, option {
-  color: $black;
-}
-
 input {
   color: $black;
 }

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -65,7 +65,7 @@ It is just like counting in decimal except we reach 10 much sooner.
 
 | Binary     | Explanation   |
 |:----------:|:-------------:|
-| 0          | We start a    |
+| 0          | We start at 0    |
 | 1          | Then 1        |
 | **1**0     | Now start back at 0 again, **but add 1 on the left**|
 | 11         | 1 more        |


### PR DESCRIPTION
Fixes #232 
Removed the overriding CSS(overrides the body-text-color in dark theme) for the select element fixing the color to be black.
Before:-
![Screenshot (603)](https://user-images.githubusercontent.com/43378325/74925336-0b049300-53fa-11ea-8dfb-c4f9b6b5c414.png)

After:-
Dark Theme-
![Screenshot (605)](https://user-images.githubusercontent.com/43378325/74925446-39826e00-53fa-11ea-91bf-0896b7250b3f.png)

Light Theme-
![Screenshot (604)](https://user-images.githubusercontent.com/43378325/74925456-3f784f00-53fa-11ea-95fe-5bf95de40a79.png)

