### PR TITLE
#285 Redesigned SVG paths for dark mode

### DIFF
--- a/_includes/binary2.html
+++ b/_includes/binary2.html
@@ -156,7 +156,7 @@
     #binary			{width: 100%;}
     #decimal		{font-family: Arial, Helvetica, sans-serif; float: left; font-size: 5vw; width: 21vw; margin: 2.7vw 0 0 2vw; float: left}
     .column_heading	{font-size: 1.6vw;}
-    .binary			{width: 620px; margin: auto}
+    .binary			{width: 620px; margin: auto; display: flex}
     #container		{width: 560px; display: block; margin: auto; margin-bottom :30px}
     #too_big		{display: none; font-style: italic; clear: left}
     #operators		{width: 680px; margin: auto; margin-left: -20%}

--- a/_sass/color_schemes/dark.scss
+++ b/_sass/color_schemes/dark.scss
@@ -12,3 +12,4 @@ $btn-primary-color: $blue-200;
 $base-button-color: $grey-dk-250;
 
 $code-background-color: $grey-dk-250;
+$base-svg-path: $white;

--- a/_sass/support/_variables.scss
+++ b/_sass/support/_variables.scss
@@ -61,6 +61,7 @@ $nav-child-link-color: $grey-dk-100 !default;
 $link-color: $purple-000 !default;
 $btn-primary-color: $purple-100 !default;
 $base-button-color: #f7f7f7 !default;
+$base-svg-path: $black !default;
 
 //
 // Media queries in pixels

--- a/_sass/svg_paths.scss
+++ b/_sass/svg_paths.scss
@@ -2,6 +2,6 @@ svg path {
   stroke: $base-svg-path;
 }
 
-#soda_machine_fsm_canvas defs path {
+defs path {
   stroke: none;
 }

--- a/_sass/svg_paths.scss
+++ b/_sass/svg_paths.scss
@@ -1,0 +1,7 @@
+svg path {
+  stroke: $base-svg-path;
+}
+
+#soda_machine_fsm_canvas defs path {
+  stroke: none;
+}

--- a/assets/css/dark-mode-preview.scss
+++ b/assets/css/dark-mode-preview.scss
@@ -35,6 +35,7 @@
 @import "./code";
 @import "./utilities/utilities";
 @import "./selects";
+@import "./svg_paths";
 
 //
 // Import custom overrides

--- a/assets/css/just-the-docs.scss
+++ b/assets/css/just-the-docs.scss
@@ -43,3 +43,4 @@
 @import "./code";
 @import "./utilities/utilities";
 @import "./selects";
+@import "./svg_paths";

--- a/assets/js/interactive_soda_machine.js
+++ b/assets/js/interactive_soda_machine.js
@@ -113,14 +113,14 @@ soda_machine_fsm.initialize = function() {
 
 	//Circles
 	fsm_circles[0] = paper.circle(75,110,50).attr({'stroke-width':'2'});
-	fsm_circles[1] = paper.circle(275,110,50).attr({'stroke-width':'2'});
-	fsm_circles[2] = paper.circle(475,110,50).attr({'stroke-width':'2'});
-	fsm_circles[3] = paper.circle(675,110,50).attr({'stroke-width':'2'});
-	fsm_circles[4] = paper.circle(875,110,50).attr({'stroke-width':'2'});
-	fsm_circles[5] = paper.circle(875,260,50).attr({'stroke-width':'2'});
-	fsm_circles[6] = paper.circle(575,260,50).attr({'stroke-width':'2'});
-	fsm_circles[7] = paper.circle(375,260,50).attr({'stroke-width':'2'});
-	fsm_circles[8] = paper.circle(175,260,50).attr({'stroke-width':'2'});
+	fsm_circles[1] = paper.circle(275,110,50).attr({'stroke-width':'2', 'fill':'white'});
+	fsm_circles[2] = paper.circle(475,110,50).attr({'stroke-width':'2', 'fill':'white'});
+	fsm_circles[3] = paper.circle(675,110,50).attr({'stroke-width':'2', 'fill':'white'});
+	fsm_circles[4] = paper.circle(875,110,50).attr({'stroke-width':'2', 'fill':'white'});
+	fsm_circles[5] = paper.circle(875,260,50).attr({'stroke-width':'2', 'fill':'white'});
+	fsm_circles[6] = paper.circle(575,260,50).attr({'stroke-width':'2', 'fill':'white'});
+	fsm_circles[7] = paper.circle(375,260,50).attr({'stroke-width':'2', 'fill':'white'});
+	fsm_circles[8] = paper.circle(175,260,50).attr({'stroke-width':'2', 'fill':'white'});
 
 	//arrows
 	fsm_arrows[0][3] = paper.path("M110.35,74.65 q264.65,-150,529.3,0").attr({'stroke-width':'2', 'arrow-end': 'classic-wide-long'});


### PR DESCRIPTION
Fixes #285 
**Redesigned svg paths for dark mode.**

## Before:->
![1](https://user-images.githubusercontent.com/52625909/82115428-43f59f00-9780-11ea-8b52-e816ae2fbf10.jpg)

## After:->
![2](https://user-images.githubusercontent.com/52625909/82115431-51128e00-9780-11ea-8427-630c2394ac3e.jpg)


<!-- what all has been done in this pull request -->

<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add a link from the checks tab after checks complete)
