### PR TITLE
Table of Contents rendered at the bottom of page, fixed //WIP

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -176,8 +176,8 @@
           </nav>
           {% endif %} {% endunless %}
           <div id="main-content" class="page-content" role="main">
-            {{ content }} {% if page.has_children == true and page.has_toc !=
-            false %}
+            {{ content }} {% if page.has_children == true and page.has_toc ==
+            true %}
             <hr />
             <h2 class="text-delta">Table of contents</h2>
             {% assign children_list = site.pages | sort:"nav_order" %}


### PR DESCRIPTION
<!-- Thank you for contributing to this repository, it is much appreciated! Make sure that you follow this template strictly, Pull requests won't be merged if the template is not properly filled.
Also keep in mind that the maintainers get notifications of all events on the repository, therefore avoid unnecessary mentions when opening pull requests. Else, feel free to ask queries or for support.
-->
A meaningful title for PR, not like: made changes to xyz.md

<!--
It's always a good practice to accompany a pull request with an issue. Use either of the two mentioned below. Remove the one you are not using.
- use "Fixes" only when the pull request completely satisfies the issue
- use "Ref" only when the pull request partially satisfies the issue
-->
Fixes #
The table of contents in the following pages was rendered at the end of the page. My changes will remove this bug. Further I will add a hardcoded Table of contents for these pages as there are only four and can be done via mentioning them.
Pages: Combinational Logic, MSI Components, Flipflops, and Registers.
Issue can be clearly depicted in the image below::
![image](https://user-images.githubusercontent.com/44001310/82440461-f481dc80-9ab9-11ea-84b7-2d41bfd3b994.png)
My changes can be seen on the deployment link
Ref #
https://deploy-preview-330--tender-ardinghelli-ebb79f.netlify.app/docs/combinational
https://deploy-preview-330--tender-ardinghelli-ebb79f.netlify.app/docs/flipflop
https://deploy-preview-330--tender-ardinghelli-ebb79f.netlify.app/docs/msi
https://deploy-preview-330--tender-ardinghelli-ebb79f.netlify.app/docs/register
<!-- what all has been done in this pull request -->
#### Changes done:
Rendering of Table of Contents in the four pages mentioned above was removed.


<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
