### PR TITLE
Add previous and next buttons to all pages (Fixes #73 and same as #160)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,8 +26,56 @@
     box-shadow: none;
   }
 </style>
-<body>
 
+{% assign parent = page.parent %}
+{% assign pages_list = site.html_pages | sort:"nav_order" %}
+{% assign previous_page = null %}
+{% assign next_page = null %}
+{% assign current_page = false %}
+
+{% for single_page in pages_list %}
+  {% if single_page.parent == parent %}
+    {% if single_page.title == page.title %}
+      {% assign current_page = true %}
+    {% elsif current_page %}
+      {% if page.has_children == null %}
+        {% assign next_page = single_page.url %}
+      {% endif %}
+      {% break %}
+    {% else %}
+      {% assign previous_page = single_page.url %}
+    {% endif %}
+  {% elsif single_page.parent == page.title %}
+    {% if single_page.nav_order == 1 %}
+      {% assign next_page = single_page.url %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{% assign current_page = false %}
+{% if next_page == null or previous_page == null %}
+  {% if page.parent != null %}
+    {% for single_page in pages_list %}
+      {% if single_page.title == page.parent %}
+        {% assign current_page = true %}
+        {% if previous_page == null %}
+          {% assign previous_page = single_page.url %}
+        {% endif %}
+      {% elsif current_page %}
+        {% if next_page == null %}
+          {% assign next_page = single_page.url %}
+        {% endif %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
+
+{% if page.nav_order == 1 and page.parent == null %}
+  {% assign previous_page = null %}
+{% endif %}
+
+<body>
     <div class="page-wrap">
       <div class="side-bar" id="sidebar">
         <a href="https://circuitverse.org/" class="site-title fs-6 lh-tight"
@@ -146,55 +194,7 @@
                   <i class="fas fa-align-left"></i>
                   <span>Sidebar</span>
                 </button>
-                <div id="prev-next-controls">
-                  {% assign parent = page.parent %}
-                  {% assign pages_list = site.html_pages | sort:"nav_order" %}
-                  {% assign previous_page = null %}
-                  {% assign next_page = null %}
-                  {% assign current_page = false %}
-    
-                  {% for single_page in pages_list %}
-                    {% if single_page.parent == parent %}
-                      {% if single_page.title == page.title %}
-                        {% assign current_page = true %}
-                      {% elsif current_page %}
-                        {% if page.has_children == null %}
-                          {% assign next_page = single_page.url %}
-                        {% endif %}
-                        {% break %}
-                      {% else %}
-                        {% assign previous_page = single_page.url %}
-                      {% endif %}
-                    {% elsif single_page.parent == page.title %}
-                      {% if single_page.nav_order == 1 %}
-                        {% assign next_page = single_page.url %}
-                      {% endif %}
-                    {% endif %}
-                  {% endfor %}
-    
-                  {% assign current_page = false %}
-                  {% if next_page == null or previous_page == null %}
-                    {% if page.parent != null %}
-                      {% for single_page in pages_list %}
-                        {% if single_page.title == page.parent %}
-                          {% assign current_page = true %}
-                          {% if previous_page == null %}
-                            {% assign previous_page = single_page.url %}
-                          {% endif %}
-                        {% elsif current_page %}
-                          {% if next_page == null %}
-                            {% assign next_page = single_page.url %}
-                          {% endif %}
-                          {% break %}
-                        {% endif %}
-                      {% endfor %}
-                    {% endif %}
-                  {% endif %}
-    
-                  {% if page.nav_order == 1 and page.parent == null %}
-                    {% assign previous_page = null %}
-                  {% endif %}
-    
+                <div class="prev-next-controls">
                   {% if previous_page != null %}
                     <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
                   {% endif %}
@@ -226,21 +226,31 @@
             </nav>
           {% endif %} {% endunless %}
             <div id="main-content" class="page-content" role="main">
-              {{ content }} {% if page.has_children == true and page.has_toc ==
-              true %}
-              <hr />
-              <h2 class="text-delta">Table of contents</h2>
-              {% assign children_list = site.pages | sort:"nav_order" %}
-              <ul>
-                {% for child in children_list %} {% if child.parent == page.title
-                and child.title != page.title %}
-                  <li>
-                    <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>
-                  </li>
-                {% endif %} {% endfor %}
-              </ul>
-            {% endif %}
-          </div>
+              {{ content }} 
+              
+              <div class="prev-next-controls">
+                {% if previous_page != null %}
+                  <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
+                {% endif %}
+                {% if next_page != null %}
+                  <a href="{{ next_page }}" class="btn btn-info">Next</a>
+                {% endif %}
+              </div>
+              
+              {% if page.has_children == true and page.has_toc == true %}
+                <hr />
+                <h2 class="text-delta">Table of contents</h2>
+                {% assign children_list = site.pages | sort:"nav_order" %}
+                <ul>
+                  {% for child in children_list %} {% if child.parent == page.title
+                  and child.title != page.title %}
+                    <li>
+                      <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>
+                    </li>
+                  {% endif %} {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
           <br />
         </div>
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -190,17 +190,21 @@
         <div id="mainhome" class="main-content">
           <div id="content">
             <nav class="navbar navbar-expand-lg navbar-light bg-light container-fluid">
-                <button type="button" id="sidebarCollapse" class="btn btn-info new">
+                <button type="button" id="sidebarCollapse" class="btn btn-info new mr-3">
                   <i class="fas fa-align-left"></i>
                   <span>Sidebar</span>
                 </button>
                 <div class="prev-next-controls">
-                  {% if previous_page != null %}
-                    <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
-                  {% endif %}
-                  {% if next_page != null %}
-                    <a href="{{ next_page }}" class="btn btn-info">Next</a>
-                  {% endif %}
+                  <div>
+                    {% if previous_page != null %}
+                      <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
+                    {% endif %}
+                  </div>
+                  <div>
+                    {% if next_page != null %}
+                      <a href="{{ next_page }}" class="btn btn-info">Next</a>
+                    {% endif %}
+                  </div>
               </div>
             </nav>
           </div>
@@ -228,13 +232,17 @@
             <div id="main-content" class="page-content" role="main">
               {{ content }} 
               
-              <div class="prev-next-controls">
-                {% if previous_page != null %}
-                  <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
-                {% endif %}
-                {% if next_page != null %}
-                  <a href="{{ next_page }}" class="btn btn-info">Next</a>
-                {% endif %}
+              <div class="prev-next-controls mt-3">
+                <div>
+                  {% if previous_page != null %}
+                    <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
+                  {% endif %}
+                </div>
+                <div>
+                  {% if next_page != null %}
+                    <a href="{{ next_page }}" class="btn btn-info">Next</a>
+                  {% endif %}
+                </div>
               </div>
               
               {% if page.has_children == true and page.has_toc == true %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,7 +49,7 @@
       </div>
       <div class="main-content-wrap js-main-content" tabindex="0">
         <div class="page-header">
-          <div id="headerid" class="main-content">
+          <div id="headerid" class="main-content main-content-header">
             {% if site.search_enabled != nil %}
             <div class="search js-search">
               <div class="search-input-wrap">
@@ -141,54 +141,104 @@
         </div>
         <div id="mainhome" class="main-content">
           <div id="content">
-            <nav class="navbar navbar-expand-lg navbar-light bg-light">
-              <div class="container-fluid">
-                <button
-                  type="button"
-                  id="sidebarCollapse"
-                  class="btn btn-info new"
-                >
+            <nav class="navbar navbar-expand-lg navbar-light bg-light container-fluid">
+                <button type="button" id="sidebarCollapse" class="btn btn-info new">
                   <i class="fas fa-align-left"></i>
                   <span>Sidebar</span>
                 </button>
+                <div id="prev-next-controls">
+                  {% assign parent = page.parent %}
+                  {% assign pages_list = site.html_pages | sort:"nav_order" %}
+                  {% assign previous_page = null %}
+                  {% assign next_page = null %}
+                  {% assign current_page = false %}
+    
+                  {% for single_page in pages_list %}
+                    {% if single_page.parent == parent %}
+                      {% if single_page.title == page.title %}
+                        {% assign current_page = true %}
+                      {% elsif current_page %}
+                        {% if page.has_children == null %}
+                          {% assign next_page = single_page.url %}
+                        {% endif %}
+                        {% break %}
+                      {% else %}
+                        {% assign previous_page = single_page.url %}
+                      {% endif %}
+                    {% elsif single_page.parent == page.title %}
+                      {% if single_page.nav_order == 1 %}
+                        {% assign next_page = single_page.url %}
+                      {% endif %}
+                    {% endif %}
+                  {% endfor %}
+    
+                  {% assign current_page = false %}
+                  {% if next_page == null or previous_page == null %}
+                    {% if page.parent != null %}
+                      {% for single_page in pages_list %}
+                        {% if single_page.title == page.parent %}
+                          {% assign current_page = true %}
+                          {% if previous_page == null %}
+                            {% assign previous_page = single_page.url %}
+                          {% endif %}
+                        {% elsif current_page %}
+                          {% if next_page == null %}
+                            {% assign next_page = single_page.url %}
+                          {% endif %}
+                          {% break %}
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+                  {% endif %}
+    
+                  {% if page.nav_order == 1 and page.parent == null %}
+                    {% assign previous_page = null %}
+                  {% endif %}
+    
+                  {% if previous_page != null %}
+                    <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
+                  {% endif %}
+                  {% if next_page != null %}
+                    <a href="{{ next_page }}" class="btn btn-info">Next</a>
+                  {% endif %}
               </div>
             </nav>
           </div>
           {% unless page.url == "/" %} {% if page.parent %}
-          <nav id="breadcrumb-nav" class="breadcrumb-nav">
-            <ol class="breadcrumb-nav-list">
-              {% if page.grand_parent %}
-              <li class="breadcrumb-nav-list-item">
-                <a href="{{ first_level_url }}">{{ page.grand_parent }}</a>
-              </li>
-              <li class="breadcrumb-nav-list-item">
-                <a href="{{ second_level_url }}">{{ page.parent }}</a>
-              </li>
-              {% else %}
-              <li class="breadcrumb-nav-list-item">
-                <a href="{{ first_level_url }}">{{ page.parent }}</a>
-              </li>
-              {% endif %}
-              <li class="breadcrumb-nav-list-item">
-                <span>{{ page.title }}</span>
-              </li>
-            </ol>
-          </nav>
+            <nav id="breadcrumb-nav" class="breadcrumb-nav">
+              <ol class="breadcrumb-nav-list">
+                {% if page.grand_parent %}
+                <li class="breadcrumb-nav-list-item">
+                  <a href="{{ first_level_url }}">{{ page.grand_parent }}</a>
+                </li>
+                <li class="breadcrumb-nav-list-item">
+                  <a href="{{ second_level_url }}">{{ page.parent }}</a>
+                </li>
+                {% else %}
+                <li class="breadcrumb-nav-list-item">
+                  <a href="{{ first_level_url }}">{{ page.parent }}</a>
+                </li>
+                {% endif %}
+                <li class="breadcrumb-nav-list-item">
+                  <span>{{ page.title }}</span>
+                </li>
+              </ol>
+            </nav>
           {% endif %} {% endunless %}
-          <div id="main-content" class="page-content" role="main">
-            {{ content }} {% if page.has_children == true and page.has_toc ==
-            true %}
-            <hr />
-            <h2 class="text-delta">Table of contents</h2>
-            {% assign children_list = site.pages | sort:"nav_order" %}
-            <ul>
-              {% for child in children_list %} {% if child.parent == page.title
-              and child.title != page.title %}
-              <li>
-                <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>
-              </li>
-              {% endif %} {% endfor %}
-            </ul>
+            <div id="main-content" class="page-content" role="main">
+              {{ content }} {% if page.has_children == true and page.has_toc ==
+              true %}
+              <hr />
+              <h2 class="text-delta">Table of contents</h2>
+              {% assign children_list = site.pages | sort:"nav_order" %}
+              <ul>
+                {% for child in children_list %} {% if child.parent == page.title
+                and child.title != page.title %}
+                  <li>
+                    <a href="{{ child.url | absolute_url }}">{{ child.title }}</a>
+                  </li>
+                {% endif %} {% endfor %}
+              </ul>
             {% endif %}
           </div>
           <br />

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -85,7 +85,7 @@
     background-color: $body-background-color;
   }
 
-  .main-content {
+  .main-content-header {
     padding-top: 0;
 
     @include mq(md) {

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -168,3 +168,8 @@
   display: flex;
   justify-content: space-between;
 }
+.prev-next-controls {
+  display: flex;
+  justify-content: space-between;
+  flex-grow: 1;
+}

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -168,8 +168,9 @@
   display: flex;
   justify-content: space-between;
 }
+
 .prev-next-controls {
   display: flex;
-  justify-content: space-between;
   flex-grow: 1;
+  justify-content: space-between;
 }

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -163,3 +163,8 @@
     }
   }
 }
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+}

--- a/docs/Combinational/N-Bit Parallel Adder & Subtractor.md
+++ b/docs/Combinational/N-Bit Parallel Adder & Subtractor.md
@@ -58,5 +58,3 @@ If A > B Cout = 0 and the result of binary form (A-B) then Cout = 1 and the resu
 ## 8 Bit Full Adder And Subtractor   
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/2018" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/Combinational/full_adder.md
+++ b/docs/Combinational/full_adder.md
@@ -45,5 +45,3 @@ The full adder is a three-input and two output combinational circuit.
 ## Ripple Carry Adder
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/248" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/Combinational/full_sub.md
+++ b/docs/Combinational/full_sub.md
@@ -33,5 +33,3 @@ A is the 'minuend', B is 'subtrahend', C is the 'borrow' produced by the previou
 ## Full Subtractor From Universal Gates
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/45278" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/Combinational/half_adder.md
+++ b/docs/Combinational/half_adder.md
@@ -35,5 +35,3 @@ This circuit has two outputs **carry** and **sum**.
 <div style="text-align:center"><img src="../../assets/images/halfadder_circuitdiagram.jpg" /></div>
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/43463" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/Combinational/half_sub.md
+++ b/docs/Combinational/half_sub.md
@@ -29,5 +29,3 @@ In the subtraction (A-B), A is called a Minuend bit and B is called a Subtrahend
 <div style="text-align:center"><img src="../../assets/images/halfsubstrator_circuitdiagram.jpg" /></div>
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/12120" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/Latches/d_latch.md
+++ b/docs/Latches/d_latch.md
@@ -32,5 +32,3 @@ In this module, we implemented various Latches by providing the cross coupling b
 
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/4276" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/Latches/jk_latch.md
+++ b/docs/Latches/jk_latch.md
@@ -18,6 +18,3 @@ JK latch is similar to RS latch. This latch consists of 2 inputs J and K as show
 |  0     |    1    |    0     |
 |  1     |    0    |    1     |
 |  1     |    1    |  Q(t)'   |
-
-
-{% include disqus.html %}

--- a/docs/Latches/sr_latch.md
+++ b/docs/Latches/sr_latch.md
@@ -37,5 +37,3 @@ Therefore, SR Latch performs three types of functions such as Hold, Set & Reset 
 
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/13774" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/Latches/t_latch.md
+++ b/docs/Latches/t_latch.md
@@ -16,6 +16,3 @@ T latch is formed when the inputs of the JK latch are shorted. When the input is
 |  0     |    1    |    1     |
 |  1     |    0    |    1     |
 |  1     |    1    |    0     |
-
-
-{% include disqus.html %}

--- a/docs/MSI/decoder.md
+++ b/docs/MSI/decoder.md
@@ -51,5 +51,3 @@ It shows that each output is 1 for only a specific combination of inputs.
 
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/763" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/MSI/demux.md
+++ b/docs/MSI/demux.md
@@ -42,6 +42,3 @@ A de-multiplexer is equivalent to a single pole multiple way switch as shown in 
 ### 1 : 16 demultiplexer
 A 1 : 16 demultiplexer can be implemented using **two** 1 : 8 demultiplexers.
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/44796" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}
-

--- a/docs/MSI/encoder.md
+++ b/docs/MSI/encoder.md
@@ -62,7 +62,3 @@ The Octal to Binary Encoder encoder usually consists of 8 inputs lines and 3 out
 ## Hexadecimal to Binary Encoder
 
 The Hexadecimal to Binary Encoder encoder usually consists of 16 inputs lines and 3 outputs lines. The input is a number written in base 16 and the output is its corresponding equivalent number in base 2.
-
-
-
-{% include disqus.html %}

--- a/docs/MSI/mux.md
+++ b/docs/MSI/mux.md
@@ -56,5 +56,3 @@ It can be implemented with **two** 8 : 1 multiplexers:
 It can also be implemented with **five** 4 : 1 multiplexers:
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/44804" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
 
-{% include disqus.html %}
-

--- a/docs/flipflop/d_flipflop.md
+++ b/docs/flipflop/d_flipflop.md
@@ -36,5 +36,3 @@ Therefore, D flip-flop always Hold the information, which is available on data i
 Next state of D flip-flop is always equal to data input, D for every positive transition of the clock signal. Hence, D flip-flops can be used in registers, shift registers and some of the counters.
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/12254" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/flipflop/jk_flipflop.md
+++ b/docs/flipflop/jk_flipflop.md
@@ -56,5 +56,3 @@ The maximum possible groupings of adjacent ones are already shown in the figure.
 ```
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/12263" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/flipflop/masterslave_jk_flipflop.md
+++ b/docs/flipflop/masterslave_jk_flipflop.md
@@ -70,5 +70,3 @@ Here, Q(n) is the present state and Q(n+1) is the next state.
 Q(n+1) = Q(n)'J + Q(n)K'
 ````
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/47630" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/flipflop/sr_flipflop.md
+++ b/docs/flipflop/sr_flipflop.md
@@ -57,5 +57,3 @@ The maximum possible groupings of adjacent ones are already shown in the figure.
 ```
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/12264" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/flipflop/t_flipflop.md
+++ b/docs/flipflop/t_flipflop.md
@@ -56,5 +56,3 @@ The output of T flip-flop always toggles for every positive transition of the cl
 
 
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/12258" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-{% include disqus.html %}

--- a/docs/jk_race_around_condition.md
+++ b/docs/jk_race_around_condition.md
@@ -104,5 +104,3 @@ If the clock is High for a time interval less than the propagation delay of the 
 
 If the flip flop is made to toggle over one clock period then racing around condition can be eliminated.
 This is done by using Master-Slave JK flip-flop.
-
-{% include disqus.html %}

--- a/docs/nand_gate_method.md
+++ b/docs/nand_gate_method.md
@@ -63,7 +63,4 @@ Notice that there are input elements that are present in the negative form, name
 <iframe width="600px" height="300px" src="https://circuitverse.org/simulator/embed/93441" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen></iframe>
 
 
-{% include disqus.html %}
-
-
 

--- a/docs/registers/pp.md
+++ b/docs/registers/pp.md
@@ -30,5 +30,3 @@ Only the clock pulse is essential to load all the binary bits.
 
 
 <div style="text-align:center"><img src="../../assets/images/pipo_blockdiagram.jpg" /></div>
-
-{% include disqus.html %}

--- a/docs/registers/ps.md
+++ b/docs/registers/ps.md
@@ -47,5 +47,3 @@ Thus, the parallel-in serial-out operation takes place.
 
 
 <div style="text-align:center"><img src="../../assets/images/piso_blockdiagram.jpg" /></div>
-
-{% include disqus.html %}

--- a/docs/registers/sp.md
+++ b/docs/registers/sp.md
@@ -30,5 +30,3 @@ nav_order: 2
 ## Block Diagram
 
 <div style="text-align:center"><img src="../../assets/images/sipo_blockdiagram.jpg" /></div>
-
-{% include disqus.html %}

--- a/docs/registers/ss.md
+++ b/docs/registers/ss.md
@@ -49,5 +49,3 @@ Similarly with Din = 1 and with the fourth negative clock edge arriving, the sto
 
 ## Waveforms
 <div style="text-align:center"><img src="../../assets/images/siso_waveform.jpg" /></div>
-
-{% include disqus.html %}

--- a/docs/universal_gates.md
+++ b/docs/universal_gates.md
@@ -53,6 +53,3 @@ The only time the NAND gate output is 0 is when both inputs are 1. Therefore, by
 ### Implementing AND gate
 The AND gate is simply the output of a NAND gate inverted.
 <iframe width="600px" height="400px" src="https://circuitverse.org/simulator/embed/45180" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
-
-
-{% include disqus.html %}


### PR DESCRIPTION
An duplicate of #160 (as the branch there got too messy)

Fixes #73

Added previous and next buttons which allow the user to advance through the whole interactive book with one button.

<img width="199" alt="2020-05-21_16-44 _130" src="https://user-images.githubusercontent.com/34946235/82577177-87864980-9b82-11ea-85b4-b830733f633e.png">
