### PR TITLE
Re-ordered side-nav by switching decoder/encoder position

### DIFF
--- a/docs/MSI/decoder.md
+++ b/docs/MSI/decoder.md
@@ -2,7 +2,7 @@
 layout: default
 title: Decoder
 parent: MSI Components
-nav_order: 3
+nav_order: 4
 ---
 
 # Decoders

--- a/docs/MSI/encoder.md
+++ b/docs/MSI/encoder.md
@@ -2,7 +2,7 @@
 layout: default
 title: Encoder
 parent: MSI Components
-nav_order: 4
+nav_order: 3
 ---
 
 # Encoder


### PR DESCRIPTION
Fixes #348 

#### Changes done:
- [x] Changed nav-order in encoder.md from 4 to 3
- [x] Changed nav-order in decoder.md from 3 to 4

#### Screenshots
Changed order of encoder-decoder:

![image](https://user-images.githubusercontent.com/28871211/82682446-e627f200-9c6c-11ea-82ae-b936413e2121.png)

Preview link:
https://deploy-preview-350--tender-ardinghelli-ebb79f.netlify.app/docs/msi

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add a link from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
