### PR TITLE
WIP: simplify code contributions by fully automating the dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+tasks:
+  - init: npm install
+  - name: Jekyll
+    init: bundle install
+    command: bundle exec jekyll serve
+
+ports: 
+  - port: 4000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![download](https://github.com/CircuitVerse/CircuitVerse/raw/master/public/img/cvlogo.svg?sanitize=true)
 
-[![Slack](https://img.shields.io/badge/chat-on_slack-purple.svg?style=for-the-badge&logo=slack)](https://join.slack.com/t/circuitverse-team/shared_invite/enQtNjc4MzcyNDE5OTA3LTdjYTM5NjFiZWZlZGI2MmU1MmYzYzczNmZlZDg5MjYxYmQ4ODRjMjQxM2UyMWI5ODUzODQzMDU2ZDEzNjI4NmE)
+[![Slack](https://img.shields.io/badge/chat-on_slack-purple.svg?style=for-the-badge&logo=slack)](https://join.slack.com/t/circuitverse-team/shared_invite/enQtNjc4MzcyNDE5OTA3LTdjYTM5NjFiZWZlZGI2MmU1MmYzYzczNmZlZDg5MjYxYmQ4ODRjMjQxM2UyMWI5ODUzODQzMDU2ZDEzNjI4NmE) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/CircuitVerse/Interactive-Book) 
 
 [Join Mailing List](https://circuitverse.us20.list-manage.com/subscribe?u=89207abda49deef3ba56f1411&id=29473194d6)
 

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@
 title: CircuitVerse
 description: A Book to learn Digital Logic Design.
 baseurl: "/" # the subpath of your site, e.g. /blog
+# NOTICE(gitpod): use `JEKYLL_ENV="production" bundle exec jekyll build` to avoid switching on localhost for assets and comment out url
 url: "https://learn.circuitverse.org" # the base hostname & protocol for your site, e.g. http://example.com
 
 permalink:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,7 @@
 
   <link rel="shortcut icon" href="{{ "favicon.ico" | absolute_url }}" type="image/x-icon">
 
-  <link rel="stylesheet" href="{{ "/assets/css/just-the-docs.css" | absolute_url }}">
+  <link rel="stylesheet" href="{{ "{{ site.url }}/assets/css/just-the-docs.css" | absolute_url }}">
 
   {% if site.ga_tracking != nil %}
     <script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 <html lang="{{ site.lang | default: 'en-US' }}">
 {% include head.html %}
 <script src="../assets/js/module.js"></script>
-<script src="\assets\js\vendor\jquery-3.4.1.min.js"></script>
+<script src="/assets/js/vendor/jquery-3.4.1.min.js"></script>
 <script src="/assets/js/shareable-links.js"></script>
 
 <style>
@@ -30,7 +30,7 @@
 
     <div class="page-wrap">
       <div class="side-bar" id="sidebar">
-        <a href="https://circuitverse.org/" class="site-title fs-6 lh-tight"
+        <a href="{{ site.url }}" class="site-title fs-6 lh-tight"
           >{{ site.title }}</a
         >
         <span class="fs-3"


### PR DESCRIPTION
Fixes #78 

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/82969564-63df5b00-9fe9-11ea-9e1b-b91a1fc549f9.png)

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/Interactive-Book/

As I pointed out in https://github.com/CircuitVerse/Interactive-Book/issues/78#issuecomment-633609609 that styles were not showing up. 

Many Thanks to @Kreyren he was able to fix this via prefixing the `href` value with `{{ site.url }}`:

```erb
<link rel="stylesheet" href="{{ "{{ site.url }}/assets/css/just-the-docs.css" | absolute_url }}">
```

There are still many things remaining i.e the links in the sidebar does not work so I'll make those changes soon.