### PR TITLE
Removed duplicate circuit-diagram image

### DIFF
--- a/docs/Combinational/half_adder.md
+++ b/docs/Combinational/half_adder.md
@@ -32,8 +32,6 @@ This circuit has two outputs **carry** and **sum**.
 
 ## Circuit diagram
 
-<div style="text-align:center"><img src="../../assets/images/halfadder_circuitdiagram.jpg" /></div>
-
 <iframe width="100%" height="400px" src="https://circuitverse.org/simulator/embed/43463" id="projectPreview" scrolling="no" webkitAllowFullScreen mozAllowFullScreen allowFullScreen> </iframe>
 
 ## Half adder from universal gates 


### PR DESCRIPTION
Fixed #402 

#### Changes done:
- [x] Removed the div containing the circuit diagram image from [Half Adder - Circuit Diagram](https://learn.circuitverse.org/docs/Combinational/half_adder.html#circuit-diagram) section of the page.

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/28871211/83896313-90c20980-a771-11ea-8097-e262854ce9e5.png)

After:
![image](https://user-images.githubusercontent.com/28871211/83896389-b2bb8c00-a771-11ea-81c6-35d51b296377.png)

#### Preview Link(s): 
https://deploy-preview-408--tender-ardinghelli-ebb79f.netlify.app/docs/combinational/half_adder

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [x] Tried Squashing the commits into on
