### PR TITLE
[GSoD2020] Fix Broken Navigation buttons due to new structure

### DIFF
--- a/_includes/bottom_buttons.html
+++ b/_includes/bottom_buttons.html
@@ -1,12 +1,14 @@
+{%- if previous_page or next_page -%}
 <div class="prev-next-controls mt-3">
   <div>
-    {% if previous_page != null %}
-    <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
-    {% endif %}
+    {%- if previous_page -%}
+    <a href="{{ previous_page.url | absolute_url }}" class="btn btn-info">Previous</a>
+    {%- endif -%}
   </div>
   <div>
-    {% if next_page != null %}
-    <a href="{{ next_page }}" class="btn btn-info">Next</a>
-    {% endif %}
+    {%- if next_page -%}
+    <a href="{{ next_page.url | absolute_url }}" class="btn btn-info">Next</a>
+    {%- endif -%}
   </div>
 </div>
+{%- endif -%}

--- a/_includes/buttonbar.html
+++ b/_includes/buttonbar.html
@@ -1,3 +1,4 @@
+{%- if previous_page or next_page -%}
 <div id="content">
     <nav class="navbar navbar-expand-lg navbar-light bg-light container-fluid">
         <button type="button" id="sidebarCollapse" class="btn btn-info new mr-3">
@@ -6,15 +7,16 @@
         </button>
         <div class="prev-next-controls">
             <div>
-                {% if previous_page != null %}
-                <a href="{{ previous_page }}" class="btn btn-info">Previous</a>
-                {% endif %}
+                {%- if previous_page -%}
+                <a href="{{ previous_page.url | absolute_url }}" class="btn btn-info">Previous</a>
+                {%- endif -%}
             </div>
             <div>
-                {% if next_page != null %}
-                <a href="{{ next_page }}" class="btn btn-info">Next</a>
-                {% endif %}
+                {%- if next_page -%}
+                <a href="{{ next_page.url | absolute_url }}" class="btn btn-info">Next</a>
+                {%- endif -%}
             </div>
         </div>
     </nav>
 </div>
+{%- endif -%}

--- a/_includes/content_header.html
+++ b/_includes/content_header.html
@@ -1,5 +1,3 @@
 {% include general_scripts.html %}
-{% comment %} 
-{% include prev_next.html %}
-{% endcomment %} 	
+{% include prev_next.html %}	
 {% include buttonbar.html %}

--- a/_includes/prev_next.html
+++ b/_includes/prev_next.html
@@ -1,50 +1,101 @@
 <!-- -*- engine:django -*- -->
+{%- comment -%}
+Code based off https://github.com/pmarsceill/just-the-docs/blob/master/_includes/nav.html
+{%- endcomment -%}
 
-{% assign parent = page.parent %}
-{% assign pages_list = site.html_pages | sort:"nav_order" %}
-{% assign previous_page = null %}
-{% assign next_page = null %}
-{% assign current_page = false %}
+{%- assign titled_pages = site.html_pages
+	| where_exp:"item", "item.title != nil" -%}
 
-{% for single_page in pages_list %}
-    {% if single_page.parent == parent %}
-	{% if single_page.title == page.title %}
-	    {% assign current_page = true %}
-	{% elsif current_page %}
-	    {% if page.has_children == null %}
-		{% assign next_page = single_page.url %}
-	    {% endif %}
-	    {% break %}
-	{% else %}
-	    {% assign previous_page = single_page.url %}
-	{% endif %}
-    {% elsif single_page.parent == page.title %}
-	{% if single_page.nav_order == 1 %}
-	    {% assign next_page = single_page.url %}
-	{% endif %}
-    {% endif %}
-{% endfor %}
+{%- comment -%}
+The values of `title` and `nav_order` can be numbers or strings.
+Jekyll gives build failures when sorting on mixtures of different types,
+so numbers and strings need to be sorted separately.
 
-{% assign current_page = false %}
-{% if next_page == null or previous_page == null %}
-    {% if page.parent != null %}
-	{% for single_page in pages_list %}
-	    {% if single_page.title == page.parent %}
-		{% assign current_page = true %}
-		{% if previous_page == null %}
-		    {% assign previous_page = single_page.url %}
-		{% endif %}
-	    {% elsif current_page %}
-		{% if next_page == null %}
-		    {% assign next_page = single_page.url %}
-		{% endif %}
-		{% break %}
-	    {% endif %}
-	{% endfor %}
-    {% endif %}
-{% endif %}
+Here, numbers are sorted by their values, and come before all strings.
+An omitted `nav_order` value is equivalent to the page's `title` value
+(except that a numerical `title` value is treated as a string).
 
-{% if page.nav_order == 1 and page.parent == null %}
-    {% assign previous_page = null %}
-{% endif %}
+The case-sensitivity of string sorting is determined by `site.nav_sort`.
+{%- endcomment -%}
 
+{%- assign string_ordered_pages = titled_pages
+	| where_exp:"item", "item.nav_order == nil" -%}
+{%- assign nav_ordered_pages = titled_pages
+	| where_exp:"item", "item.nav_order != nil"  -%}
+
+{%- comment -%}
+The nav_ordered_pages have to be added to number_ordered_pages and
+string_ordered_pages, depending on the nav_order value.
+The first character of the jsonify result is `"` only for strings.
+{%- endcomment -%}
+{%- assign nav_ordered_groups = nav_ordered_pages
+	| group_by_exp:"item", "item.nav_order | jsonify | slice: 0" -%}
+{%- assign number_ordered_pages = "" | split:"X" -%}
+{%- for group in nav_ordered_groups -%}
+{%- if group.name == '"' -%}
+  {%- assign string_ordered_pages = string_ordered_pages | concat: group.items -%}
+{%- else -%}
+  {%- assign number_ordered_pages = number_ordered_pages | concat: group.items -%}
+{%- endif -%}
+{%- endfor -%}
+
+{%- assign sorted_number_ordered_pages = number_ordered_pages | sort:"nav_order" -%}
+
+{%- comment -%}
+The string_ordered_pages have to be sorted by nav_order, and otherwise title
+(where appending the empty string to a numeric title converts it to a string).
+After grouping them by those values, the groups are sorted, then the items
+of each group are concatenated.
+{%- endcomment -%}
+{%- assign string_ordered_groups = string_ordered_pages
+	| group_by_exp:"item", "item.nav_order | default: item.title | append:''" -%}
+{%- if site.nav_sort == 'case_insensitive' -%}
+{%- assign sorted_string_ordered_groups = string_ordered_groups | sort_natural:"name" -%}
+{%- else -%}
+{%- assign sorted_string_ordered_groups = string_ordered_groups | sort:"name" -%}
+{%- endif -%}
+{%- assign sorted_string_ordered_pages = "" | split:"X" -%}
+{%- for group in sorted_string_ordered_groups -%}
+{%- assign sorted_string_ordered_pages = sorted_string_ordered_pages | concat: group.items -%}
+{%- endfor -%}
+
+{%- assign pages_list = sorted_number_ordered_pages | concat: sorted_string_ordered_pages -%}
+
+{%- assign current_page = false -%}
+{%- assign previous_page = nil -%}
+{%- assign next_page = nil -%}
+
+{%- for node in pages_list -%}
+  {%- unless node.nav_exclude -%}
+    {%- if node.parent == nil and node.title -%}
+
+      {%- if page.url == node.url -%}
+        {%- assign current_page = true -%}
+      {%- elsif current_page -%}
+        {%- assign next_page = node -%}
+        {%- break -%}
+      {%- else -%}
+        {%- assign previous_page = node -%}
+      {%- endif -%}
+
+      {%- if node.has_children -%}
+        {%- assign children_list = pages_list | where: "parent", node.title -%}
+        {%- for child in children_list -%}
+          {%- if page.url == child.url -%}
+           {%- assign current_page = true -%}
+          {%- elsif current_page -%}
+            {%- assign next_page = child -%}
+            {%- break -%}
+          {%- else -%}
+           {%- assign previous_page = child -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+
+      {%- if next_page != nil -%}
+        {%- break -%}
+      {%- endif -%}
+
+    {%- endif -%}
+  {%- endunless -%}
+{%- endfor -%}

--- a/contributing_guidelines.md
+++ b/contributing_guidelines.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-nav_order: 100
+nav_order: 1000
 title: Guidelines
 disable_comments: true
 description: ""

--- a/contributing_guidelines.org
+++ b/contributing_guidelines.org
@@ -3,7 +3,7 @@
 #+BEGIN_EXPORT html
 ---
 layout: default
-nav_order: 100
+nav_order: 1000
 title: Guidelines
 disable_comments: true
 description: ""


### PR DESCRIPTION
With the new structure, the logic for finding previous and next links had to be changed.
This Pull Request fixes the broken previous navigation buttons in both top and bottom button bars.
Please bear with the styling, that would be done in a separate PR due to #475  

The code for `prev_next.html` is based on https://github.com/pmarsceill/just-the-docs/blob/master/_includes/nav.html.
Assigned `nav_order` of 1000 to Guidelines page since other pages are already in the range of 100s.

Fixes #476 
Ref #460 

#### Changes done:
- [x] Fixed Broken Navigation buttons due to new structure
- [x]  Changed `nav_order` of Guidelines page for new pages.

<!-- Any changes which change how the site looks, or adds styling, or fixes any UI issue need to be accompanied 
with a screenshot showing the comparison between old and new -->
#### Screenshots
![image](https://user-images.githubusercontent.com/22657113/108466088-1ad2e380-72a9-11eb-90bd-08c5837b7faa.png)

<!-- Preview links of all the files that have been changed/updated -->
#### Preview Link(s): 
https://deploy-preview-511--learncircuitverse.netlify.app/
https://deploy-preview-511--learncircuitverse.netlify.app/docs/binary-representation/number-bases.html
(Navigation is best experienced when run in localhost because of link changes)

<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
