### PR TITLE
Utils: API gen: Use utf-8 encoding to preserve Unicode chars.

### DIFF
--- a/utils/api_generator.py
+++ b/utils/api_generator.py
@@ -38,7 +38,7 @@ deployed_host = args.dest_host
 
 
 def get_response(url):
-    return urllib.request.urlopen(url).read().decode()
+    return urllib.request.urlopen(url).read().decode('utf-8')
 
 
 def get_json(response):
@@ -48,7 +48,7 @@ def get_json(response):
 def save_content(content, file_path):
     print(f'Saving to {file_path}')
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
-    f = open(file_path, "w")
+    f = open(file_path, "w", encoding='utf-8')
     f.write(content)
     f.close()
 


### PR DESCRIPTION
API Generator was not using UTF-8 encoding by default as some Unicode characters were not displayed in API responses as compared to raw markdown pages.

Original/Expected -
```
This combinational circuit has ‘n’ input variables and ‘m’ outputs. Each combination of input variables will affect the output(s).
```

API Response Content -
```
This combinational circuit has â€˜nâ€™ input variables and â€˜mâ€™ outputs. Each combination of input variables will affect the output(s).
```

This PR fixes that by reading UTF-8 and writing UTF-8 response to preserve the Unicode characters.