### PR TITLE
Typo fix on contributing_guidelines.md

### DIFF
--- a/contributing_guidelines.md
+++ b/contributing_guidelines.md
@@ -22,7 +22,7 @@ description: ""
 
 ## About this guidelines
 
-This guidelines documentation was started on September 2020 as part of the Goggle Season of Docs 2020 initiative.
+This guidelines documentation was started on September 2020 as part of the Google Season of Docs 2020 initiative.
 
 
 ### Revision history


### PR DESCRIPTION
# Fixed a small typo on contributing_guidelines.md

#### Changes done:
- [x] Changed `Goggle` to `Google` on Line 25

#### Screenshots
Before:
![Before Image](https://user-images.githubusercontent.com/53386868/125842612-3ad97fa5-9ad8-42d8-9902-dac5d58385fc.png)
After:
![After Image](https://user-images.githubusercontent.com/53386868/125843026-5d4d0d1b-b218-4fe9-9795-4f0f24e0599a.png)

#### Preview Link(s): 
https://github.com/indujaaaa/Interactive-Book/commit/f90d9121fb415f8229da58bf933d2a8fd798d348

#### ✅️ By submitting this PR, I have verified the following

- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
