### PR TITLE
Changed the color of footer copyright text to white Fixes #553

### DIFF
--- a/assets/css/just-the-docs-circuitversedark.scss
+++ b/assets/css/just-the-docs-circuitversedark.scss
@@ -1,3 +1,7 @@
 ---
 ---
 {% include css/just-the-docs.scss.liquid color_scheme="circuitversedark" %}
+
+.text-grey-dk-100 {
+    color: white!important;
+}


### PR DESCRIPTION

Fixes #553 



<!-- what all has been done in this pull request -->
#### Changes done:
- Changed the color of footer copyright text from grey to white color -


#### Screenshots
 ### Initially 

![image](https://user-images.githubusercontent.com/87171452/142752285-a8b1f505-1f37-44d3-9b5c-5cd856493bd2.png)

### Finally 

![image](https://user-images.githubusercontent.com/87171452/142752268-8e27b235-28f2-40bc-a1d2-6ac5f3f0e89b.png)




<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [yes] Checked to see if a similar PR has already been opened 🤔️
- [yes] Reviewed the contributing guidelines 🔍️
- [yes] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [yes] Tried Squashing the commits into one
