### PR TITLE
Solved scrollbar is collapsed for first-time issue Fixes #582

### DIFF
--- a/_includes/general_scripts.html
+++ b/_includes/general_scripts.html
@@ -5,7 +5,11 @@
 	var sidebar = document.querySelector("div.side-bar");
 	var mainContent = document.getElementById("top");
 	var isSidebar = localStorage.getItem('Sidebar');
-	if (isSidebar == 0 || isSidebar == null) {
+	if (isSidebar == null) {
+		sidebar.classList.remove('active');
+		mainContent.classList.remove('sidebar-toggle');
+	}
+	else if (isSidebar == 0) {
 		isSidebar = 0;
 		localStorage.setItem('Sidebar', isSidebar);
 		sidebar.classList.add('active');

--- a/_includes/general_scripts.html
+++ b/_includes/general_scripts.html
@@ -5,6 +5,7 @@
 	var sidebar = document.querySelector("div.side-bar");
 	var mainContent = document.getElementById("top");
 	var isSidebar = localStorage.getItem('Sidebar');
+	
 	if (isSidebar == null) {
 		sidebar.classList.remove('active');
 		mainContent.classList.remove('sidebar-toggle');


### PR DESCRIPTION
Fixes #582 



<!-- what all has been done in this pull request -->
#### Changes done:
- I have solved the issue for scrollbar collapsed when open for first time . Now on opening for first time it is opened as expected 

<!-- Any changes which change how the site looks, or adds styling, or fixes any UI issue need to be accompanied 
with a screenshot showing the comparison between old and new -->
#### Screenshots
### Finally
 Now i have shown in the video by making a completely new workspace with no default value and the sidebar is now open if localstorage value is null as happens when opened for the very first time .


https://user-images.githubusercontent.com/87171452/142764724-6746f149-b85c-4886-ad6f-afd5828fda0e.mp4



<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [yes] Checked to see if a similar PR has already been opened 🤔️
- [yes] Reviewed the contributing guidelines 🔍️
- [yes] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [yes] Tried Squashing the commits into one
