### PR TITLE
Input in truth table generator is visible now in dark mode

### DIFF
--- a/_sass/color_schemes/circuitversedark.scss
+++ b/_sass/color_schemes/circuitversedark.scss
@@ -15,5 +15,5 @@ $base-svg-path: #026e57;
 $feedback-color: darken($sidebar-color, 3%);
 $table-background-color: #171326;
 
-$inputcolor: #ffffff;
+$inputcolor: #000000;
 $black: #000000;


### PR DESCRIPTION
<!-- Thank you for contributing to this repository, it is much appreciated! Make sure that you follow this template strictly, Pull requests won't be merged if the template is not properly filled.
Also keep in mind that the maintainers get notifications of all events on the repository, therefore avoid unnecessary mentions when opening pull requests. Else, feel free to ask queries or for support.
-->


<!--
It's always a good practice to accompany a pull request with an issue. Use either of the two mentioned below. Remove the one you are not using.
- use "Fixes" only when the pull request completely satisfies the issue
- use "Ref" only when the pull request partially satisfies the issue
-->
Fixes #631 

<!-- what all has been done in this pull request -->
#### Changes done:
- [x] The value in the truth table generator input is visible now in the dark mode as well.

<!-- Any changes which change how the site looks, or adds styling, or fixes any UI issue need to be accompanied 
with a screenshot showing the comparison between old and new -->
#### Screenshots
<img width="1431" alt="Screenshot 2023-01-04 at 2 05 38 AM" src="https://user-images.githubusercontent.com/44300550/210626320-ec1e5377-7380-41e7-beee-f34790c483e6.png">

