### PR TITLE
Add pending triage by default for all issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+labels: ["🐞 bug", "pending triage"]
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+labels: ["🌟 feature", "pending triage"]
 ---
 
 ## Is your feature request related to a problem? Please describe.


### PR DESCRIPTION
### Description

Improve issue workflow by Adding pending triage label to new issues. 