### PR TITLE
feat: workflow for auto validate and assign issues to requested contributor

### DIFF
--- a/.github/scripts/assign-or-comment.js
+++ b/.github/scripts/assign-or-comment.js
@@ -17,18 +17,18 @@ const assignOrComment = async () => {
       owner: owner,
       repo: repo,
       issue_number: issue_number
-    })
+    });
     const hasPendingTriagLabel = issue.labels.some((label) => {
       return (label.name === "pending triage")
-    })
+    });
     const assignees = issue.assignees;
     if (hasPendingTriagLabel) {
       await octokit.issues.createComment({
         owner: owner,
         repo: repo,
         issue_number: issue_number,
-        body: "This issue is awaiting triage from @CircuitVerse/circuitverse-core-team. You can work on this issue once the label `pending triage` is removed."
-      })
+        body: "This issue is awaiting triage from @CircuitVerse/issues-team. You can work on this issue once the label `pending triage` is removed."
+      });
     }
     else if (assignees.length !== 0) {
       await octokit.issues.createComment({
@@ -36,7 +36,7 @@ const assignOrComment = async () => {
         repo: repo,
         issue_number: issue_number,
         body: `This issue is assigned to @${assignees[0].login}. You can have a look on other open issues.`
-      })
+      });
     }
     else {
       await octokit.issues.update({
@@ -44,7 +44,7 @@ const assignOrComment = async () => {
         repo: repo,
         issue_number: issue_number,
         assignees: [github_actor]
-      })
+      });
     }
   } catch (e) {
     console.log(e);

--- a/.github/scripts/assign-or-comment.js
+++ b/.github/scripts/assign-or-comment.js
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+const { Octokit } = require("@octokit/rest");
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN
+})
+
+const owner = process.env.OWNER
+const repo = process.env.REPO_NAME
+const issue_number = process.env.ISSUE_NUMBER
+const github_actor = process.env.GITHUB_ACTOR
+
+const assignOrComment = async () => {
+  try {
+    const { data: issue } = await octokit.issues.get({
+      owner: owner,
+      repo: repo,
+      issue_number: issue_number
+    })
+    const hasPendingTriagLabel = issue.labels.some((label) => {
+      return (label.name === "pending triage")
+    })
+    const assignees = issue.assignees;
+    if (hasPendingTriagLabel) {
+      await octokit.issues.createComment({
+        owner: owner,
+        repo: repo,
+        issue_number: issue_number,
+        body: "This issue is awaiting triage from @CircuitVerse/circuitverse-core-team. You can work on this issue once the label `pending triage` is removed."
+      })
+    }
+    else if (assignees.length !== 0) {
+      await octokit.issues.createComment({
+        owner: owner,
+        repo: repo,
+        issue_number: issue_number,
+        body: `This issue is assigned to @${assignees[0].login}. You can have a look on other open issues.`
+      })
+    }
+    else {
+      await octokit.issues.update({
+        owner: owner,
+        repo: repo,
+        issue_number: issue_number,
+        assignees: [github_actor]
+      })
+    }
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+assignOrComment();

--- a/.github/workflows/issue-assign-to-contributor.yml
+++ b/.github/workflows/issue-assign-to-contributor.yml
@@ -1,0 +1,30 @@
+name: Validate and assign issue to the contributor
+run-name: "${{ github.actor }} want to work on the issue"
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    if: github.event.comment.user.login == github.actor && github.event.comment.body == '/assign'
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      
+      - name: Install node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: setup octokit
+        run: npm i @octokit/rest -f
+
+      - name: run the script
+        run: node ./.github/workflows/scripts/assign-issue-to-contributor.js
+        env:
+          OWNER: "${{ github.repository_owner }}"
+          REPO_NAME: Interactive-Book
+          ISSUE_NUMBER: "${{ github.event.issue.number }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_ACTOR: "${{ github.actor }}"


### PR DESCRIPTION
This is GitHub action for validating and assigning issues to the contributor.

Validations:
- If the issue is approved by maintainers and removed `pending triage` label from issue.
- If the issue is not assigned.
- Finally, assign to requested contributor.

Actions:
- Need to comment `/assign` in the issue.

This issue is much needed:
- Maintainers are not active everytime, this make things automated.
- The contributor who comes first got assigned, and make contributions valid.
- Make process automated and unbiased.

Depends on https://github.com/CircuitVerse/Interactive-Book/pull/644