### PR TITLE
(fix: #672): Sidebar items expander should be cursor pointer

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -17,6 +17,10 @@ input {
   color: $inputcolor;
 }
 
+.nav-list-expander:hover{
+  cursor: pointer;
+}
+
 #sidebar.active {
   display: none;
 }
@@ -196,6 +200,7 @@ $text-color: #111111;
 //
 .nav-list {
   list-style: circle url("/assets/images/nav-marker-inactive.svg") inside;
+  
 
   .nav-list-item {
     // scss-lint:disable SelectorDepth
@@ -205,6 +210,7 @@ $text-color: #111111;
 
     &.active {
       list-style: disc url("/assets/images/nav-marker-active.svg") inside;
+      cursor: pointer;
     }
   }
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -17,7 +17,7 @@ input {
   color: $inputcolor;
 }
 
-.nav-list-expander:hover{
+.nav-list-expander:hover {
   cursor: pointer;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Interactive-Book",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
### Fixed: Sidebar items expander should be cursor pointer

#### Screenshots

https://github.com/CircuitVerse/Interactive-Book/assets/101059602/90026395-5ad1-4eb2-8285-4d8be81cdb4a



#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
