### PR TITLE
fix #674: Footer content (copyright) should be in the center

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -309,3 +309,8 @@ button,
   width: 0%;
   z-index: 10000;
 }
+
+//footer
+.text-small {
+  text-align: center;
+}


### PR DESCRIPTION
## Fixes: make the copyright content in the footer section to the center.

#### Screenshots
![Screenshot 2024-01-24 235542](https://github.com/CircuitVerse/Interactive-Book/assets/99977240/e14c4d0f-0719-4473-ab98-21aead40c1ec)

#### ✅️ By submitting this PR, I have verified the following
- [X] Checked to see if a similar PR has already been opened 🤔️
- [X] Reviewed the contributing guidelines 🔍️
- [X] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [X] Tried Squashing the commits into one
