### PR TITLE
(fix #682):  Links are redirecting to the correct page.

### DIFF
--- a/docs/binary-representation/encoding-information.md
+++ b/docs/binary-representation/encoding-information.md
@@ -19,7 +19,7 @@ has_children: false
 {:toc}
 
 ## Binary flags
-The new Interactive Book  for digital logic design requires you to study [binary ](https://learn.circuitverse.org/docs/binary.html) and its uses.
+The new Interactive Book  for digital logic design requires you to study [binary ]({% link docs/binary-representation/binary-numbers.md %}) and its uses.
 In computing, a <em>flag</em> is a type of signal usually used to indicate whether something is true or false. To save time and make your program less complicated, you might want to combine these flags and send several pieces of information in one go.
 
 Imagine you wanted to send a message to your friend to indicate which subjects had set homework on a particular day. If it was only one subject, you can just send the name of the subect - e.g. English - but if there is more than one, it gets more complicated. One way to do it is to give each subject a number:
@@ -42,11 +42,11 @@ You can send combinations of subjects by adding together the numbers and sending
 {% include application1.html %}
 
 
-This only works because of the numbers I've chosen - it's a [binary ](https://learn.circuitverse.org/docs/binary.html) sequence, with each number being one of the [binary ](https://learn.circuitverse.org/docs/binary.html)column headings. 
+This only works because of the numbers I've chosen - it's a [binary ]({% link docs/binary-representation/binary-numbers.md %}) sequence, with each number being one of the [binary ]({% link docs/binary-representation/binary-numbers.md %}) column headings. 
 This means that each total can only be made up from one combination of subjects.
 
 If they'd been numbered as 1 = **English**, 2 = **Maths**, 3 = **Science**, 4 = **Computing**, etc., then it wouldn't work, because a code of 3 could represent English and Maths, or it could be Science on its own. 
-To use this technique in your programming, you need to be familiar with [bitwise logic ](https://learn.circuitverse.org/docs/binary2.html)
+To use this technique in your programming, you need to be familiar with [bitwise logic ]({% link docs/comb-ssi/logic-gates.md %})
 
 
 ## Representing a character


### PR DESCRIPTION
## Fixes: Previously, the link are redirecting to the `404 page`.  Now, it is redirecting to the correct page.

## Screenshots
### Before:
https://www.loom.com/share/6e6d381962f2468a91e0f18843781465?sid=d992f2e8-76ee-4fd1-9e61-378b5acf6c8e
### After:
https://www.loom.com/share/9ae570bc434846308e706495e1d6c002?sid=90fbe8e0-4e7f-4da7-9457-728085a50254

#### ✅️ By submitting this PR, I have verified the following
- [X] Checked to see if a similar PR has already been opened 🤔️
- [X] Reviewed the contributing guidelines 🔍️
- [X] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [X] Tried Squashing the commits into one
