### PR TITLE
(fix #687): links are functional it is not direction on 404 page.

### DIFF
--- a/docs/seq-ssi/flip-flops.md
+++ b/docs/seq-ssi/flip-flops.md
@@ -46,14 +46,15 @@ In second module, you can directly implement the flip-flop, which is edge sensit
 ## Sub-modules
 Now let us implement various flip-flops by providing the cross coupling between NOR gates. You can also implement these flip-flops by using NAND gates, as well.
 
-1. [SR flip-flop](https://learn.circuitverse.org/docs/flipflop/sr_flipflop.html)
-2. [D flip-flop](https://learn.circuitverse.org/docs/flipflop/d_flipflop.html)
-3. [JK flip-flop](https://learn.circuitverse.org/docs/flipflop/jk_flipflop.html)
-4. [T flip-flop](https://learn.circuitverse.org/docs/flipflop/t_flipflop.html)
-5. [Master-slave JK flip-flop](https://learn.circuitverse.org/docs/flipflop/masterslave_jk_flipflop.html)
+1. [SR flip-flop](#sr_flipflop)
+2. [D flip-flop](#d_flipflop)
+3. [JK flip-flop](#jk_flipflop)
+4. [T flip-flop](#t_flipflop)
+5. [Master-slave JK flip-flop](#m_flipflop)
 
 
 ## SR flip-flop
+{: .no_toc #sr_flipflop}
 
 ## Introduction
 
@@ -102,6 +103,7 @@ The maximum possible groupings of adjacent ones are already shown in the figure.
 
 
 ## D flip-flop
+{: .no_toc #d_flipflop}
 
 ## Introduction
 
@@ -130,6 +132,7 @@ Next state of D flip-flop is always equal to data input, D for every positive tr
 
 
 ## JK flip-flop
+{: .no_toc #jk_flipflop}
 
 ## Introduction
 
@@ -177,6 +180,7 @@ The maximum possible groupings of adjacent ones are already shown in the figure.
 
 
 ## T flip-flop
+{: .no_toc #t_flipflop}
 
 ## Introduction
 
@@ -222,6 +226,7 @@ The output of T flip-flop always toggles for every positive transition of the cl
 
 
 ## Master-slave JK flip-Flop
+{: .no_toc #m_flipflop}
 
 ## Introduction
 

--- a/docs/seq-ssi/latches.md
+++ b/docs/seq-ssi/latches.md
@@ -50,13 +50,14 @@ Latches are basic storage elements that operate with signal levels (rather than 
 
 Now, let us discuss about SR Latch, D Latch, JK Latch & T Latch one by one.
 
-1. [SR latch](https://learn.circuitverse.org/docs/Latches/sr_latch.html)
-2. [D latch](https://learn.circuitverse.org/docs/Latches/d_latch.html)
-3. [JK latch](https://learn.circuitverse.org/docs/Latches/jk_latch.html)
-4. [T latch](https://learn.circuitverse.org/docs/Latches/t_latch.html) 
+1. [SR latch](#sr_latch)
+2. [D latch](#d_latch)
+3. [JK latch](#jk_latch)
+4. [T latch](#t_latch) 
 
 
 ## SR latch
+{: .no_toc #sr_latch}
 
 ## Introduction
 
@@ -93,6 +94,7 @@ Therefore, SR latch performs three types of functions such as Hold, Set & Reset 
 
 
 ## D latch
+{: .no_toc #d_latch}
 
 ## Introduction
 
@@ -123,6 +125,7 @@ In this module, you implemented various Latches by providing the cross coupling 
 
 
 ## JK latch
+{: .no_toc #jk_latch}
 
 ## Introduction
 
@@ -141,6 +144,7 @@ JK latch is similar to RS latch. This latch consists of 2 inputs J and K as show
 
 
 ## T latch
+{: .no_toc #t_latch}
 
 ## Introduction
 


### PR DESCRIPTION
## Fixes: links are now functional. It is not directed to the 404 page.
### Issue Link(s): https://github.com/CircuitVerse/Interactive-Book/issues/687
#### Screenshots After changes:
- In Latches:
https://www.loom.com/share/6ccb4b724e2845eda44426ab36b4cd1c?sid=51a50a4f-c46a-4dc7-8d56-94647c7fa678 

- In Flip-flops:
https://www.loom.com/share/972857528ed9447b88109b77a050ef04?sid=5334bce0-76ef-4f64-b2cd-57a202c0fbe0 
#### ✅️ By submitting this PR, I have verified the following
- [X] Checked to see if a similar PR has already been opened 🤔️
- [X] Reviewed the contributing guidelines 🔍️
- [X] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [X] Tried Squashing the commits into one
