### PR TITLE
[Fixes #631] The input for the truth table generator is now visible in dark mode.

### DIFF
--- a/_sass/color_schemes/circuitversedark.scss
+++ b/_sass/color_schemes/circuitversedark.scss
@@ -15,5 +15,5 @@ $base-svg-path: #026e57;
 $feedback-color: darken($sidebar-color, 3%);
 $table-background-color: #171326;
 
-$inputcolor: #ffffff;
+$inputcolor: #000000;
 $black: #000000;


### PR DESCRIPTION
Fixes #631 

The input for the truth table generator is now visible in dark mode.

#### Screenshots

![image](https://github.com/CircuitVerse/Interactive-Book/assets/88142229/e79c0984-11db-4b7f-b278-fb0c28d84eaf)



<!-- Any changes which change how the site looks, or adds styling, or fixes any UI issue need to be accompanied 
with a screenshot showing the comparison between old and new -->


<!-- Preview links of all the files that have been changed/updated -->
#### Preview Link(s): 

<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [x] Tried Squashing the commits into one
