### PR TITLE
Fixed truth table input not visible in dark mode 

### DIFF
--- a/_includes/truth_table.html
+++ b/_includes/truth_table.html
@@ -46,6 +46,7 @@
         padding: 8px;
         font-family: 'Source Code Pro', monospace;
         max-width: 100%;
+        color: black;
     }
 
     .truth-table p {


### PR DESCRIPTION
Fixes #701 

<!-- what all has been done in this pull request -->
#### Changes done:
- [x] Changed the CSS color property in the truth table generator input box to black

#### Screenshots

Old:
![Screenshot from 2024-09-22 00-27-00](https://github.com/user-attachments/assets/55382fdb-1d4c-429a-9d17-7145975aa202)


New:
![Screenshot from 2024-09-22 00-27-14](https://github.com/user-attachments/assets/d610eb9a-5803-431b-9718-be545f01a6e4)


#### Preview Link(s): 


#### ✅️ By submitting this PR, I have verified the following
- [ X] Checked to see if a similar PR has already been opened 🤔️
- [ X] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [ X] Tried Squashing the commits into one
