### PR TITLE
docs: fix typo in max term definition (product → sum)

### DIFF
--- a/docs/logic-design/canonical.md
+++ b/docs/logic-design/canonical.md
@@ -171,7 +171,7 @@ In standard SOP form, the maximum possible product terms for n number of variabl
 
 ### Maxterms
 
-A max term is defined as the product of n variables, within the range of 0 ≤ i < 2<sup>n</sup>. The max term is denoted as Mi. In max term, each variable is **complemented**, if its value is assigned to 1, and each variable is **un-complemented** if its value is assigned to 0.
+A max term is defined as the sum of n variables, within the range of 0 ≤ i < 2<sup>n</sup>. The max term is denoted as Mi. In max term, each variable is **complemented**, if its value is assigned to 1, and each variable is **un-complemented** if its value is assigned to 0.
 
 For a 2-variable (x and y) Boolean function, the possible max terms are:
 ```yml


### PR DESCRIPTION
Fixes #723

#### Changes done:
- [x] Corrected the definition of max term in `canonical.md` (Line 174)
  - Changed "**product** of n variables" → "**sum** of n variables"
  - This aligns with standard logic design terminology.

#### Screenshots
Not applicable (documentation-only change)

#### Preview Link(s): 
[Interactive Book → Logic Design → Canonical Forms](https://circuitverse.org/interactive-book/logic-design/canonical.html)

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (see above)
- [x] Tried Squashing the commits into one.

Thank You


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Maxterms definition in the canonical forms guide to state it is the sum of n variables (not the product).
  * Ensures terminology aligns with standard logic design conventions.
  * Clarifies content for readers; examples remain unchanged.
  * No impact on application behavior or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->