### PR TITLE
Update footer year to 2025 (#734)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -80,7 +80,7 @@ aux_links:
 
 # Footer content 
 # appears at the bottom of every page's main content
-footer_content: "Copyright &copy; 2024 Contributors to CircuitVerse. Distributed under a [CC-by-sa] license."
+footer_content: "Copyright &copy; 2025 Contributors to CircuitVerse. Distributed under a [CC-by-sa] license."
 
 # Footer last edited timestamp
 last_edit_timestamp: false # show or hide edit time - page must have `last_modified_date` defined in the frontmatter


### PR DESCRIPTION
Fixes #734

✔️ Changes done:

 Updated the footer year in _config.yml from 2024 to 2025.

 Ensures the website displays the current year in the footer across all pages.

📸 Screenshots

Not applicable — this is a text-only backend/config update.

<!-- Preview links of all the files that have been changed/updated -->
#### Preview Link(s): 

<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
<!-- put an x inside the square brackets to mark it as done -->
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (add the link(s) for all the pages changed/updated from the checks tab after checks complete)
- [x] Tried Squashing the commits into one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year in the footer from 2024 to 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->