### PR TITLE
Fix bug #668

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -236,32 +236,32 @@ $text-color: #111111;
   padding-left: 1rem;
 }
 
+// Auxiliary Nav Styles for all screen sizes
+.aux-nav {
+  .aux-nav-list-item {
+    align-items: center;
+    display: flex;
+  }
+
+  .aux-nav-list {
+    padding-left: 10px;
+  }
+}
+
+.aux-nav-list-item .site-button {
+  background-color: $base-button-color;
+  border-radius: 3px;
+  border-width: 0;
+  box-shadow: 0 1px 2px $box-shadow, 0 3px 10px $box-shadow;
+  height: 50%;
+  margin-right: 0.5rem;
+  padding: 0.5rem;
+}
+
 @media (min-width: 50rem) {
   // Sidebar Navigation
   .site-nav {
     padding-left: 2rem;
-  }
-
-  // Auxiliary Nav Styles for tablet and above
-  .aux-nav {
-    .aux-nav-list-item {
-      align-items: center;
-      display: flex;
-    }
-
-    .aux-nav-list {
-      padding-left: 10px;
-    }
-  }
-
-  .aux-nav-list-item .site-button {
-    background-color: $base-button-color;
-    border-radius: 3px;
-    border-width: 0;
-    box-shadow: 0 1px 2px $box-shadow, 0 3px 10px $box-shadow;
-    height: 50%;
-    margin-right: 0.5rem;
-    padding: 0.5rem;
   }
 }
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -60,7 +60,7 @@ input {
 }
 
 //
-//  navigation.css
+// navigation.css
 //
 
 .flex-container {
@@ -91,7 +91,6 @@ input {
   flex-grow: 1;
   justify-content: space-between;
 
-  // Workaround for buttons bar overflow issues.
   a {
     overflow: inherit;
   }
@@ -100,6 +99,7 @@ input {
 //
 // from selects.scss
 //
+
 select {
   background-color: $base-button-color;
   border: 0;
@@ -112,6 +112,7 @@ select {
 //
 // from scg_paths.scss
 //
+
 svg path {
   stroke: $base-svg-path;
 }
@@ -123,6 +124,7 @@ defs path {
 //
 // from quiz.scss
 //
+
 $correct-color: #5cd65c;
 $incorrect-color: #ff6666;
 $default-color: #f1f1f1;
@@ -187,18 +189,13 @@ $text-color: #111111;
 }
 
 //
-// from search.scss (not included since its too different from upstream)
+// DVLS new styles
 //
 
-//
-// DVLS new styles
-// CV flavored side nav
-//
 .nav-list {
   list-style: circle url("/assets/images/nav-marker-inactive.svg") inside;
 
   .nav-list-item {
-    // scss-lint:disable SelectorDepth
     .nav-list-link {
       display: inline;
     }
@@ -218,7 +215,6 @@ $text-color: #111111;
   }
 }
 
-// Nested nav lists
 .nav-list .nav-list-item > .nav-list .nav-list-item .nav-list-link {
   padding-left: 1rem;
 
@@ -227,16 +223,12 @@ $text-color: #111111;
   }
 }
 
-// table caption style
-//.tblcap {
-// to be defined
-//}
-
 .site-nav {
   padding-left: 1rem;
 }
 
-// Auxiliary Nav Styles for all screen sizes
+
+
 .aux-nav {
   .aux-nav-list-item {
     align-items: center;
@@ -258,19 +250,23 @@ $text-color: #111111;
   padding: 0.5rem;
 }
 
+//
+// Only desktop-specific tweaks here
+//
 @media (min-width: 50rem) {
-  // Sidebar Navigation
   .site-nav {
     padding-left: 2rem;
   }
 }
 
-// Disqus Recommendations
+//
+// Other styles
+//
+
 #disqus_recommendations {
   margin-top: 20px;
 }
 
-// Scroll Back to Top Button
 .back-to-top {
   background-color: $link-color;
   color: $white;
@@ -279,7 +275,6 @@ $text-color: #111111;
   bottom: 15px;
 }
 
-// Added transitions
 a,
 h1,
 h2,
@@ -299,7 +294,6 @@ button,
   background-color: $body-background-color;
 }
 
-// progress-bar 
 #progress-bar {
   position: fixed;
   top: 0;


### PR DESCRIPTION


##  Make Dark Mode & GitHub Links Work on Mobile

### **What’s this PR about?**

While browsing the site on mobile, I noticed that the **Dark Mode toggle** and the **GitHub link** were missing from the navigation. They were present on desktop but completely inaccessible on smaller screens.

This PR fixes that issue and makes both options available on mobile as well.

---

### **What was happening?**

The project uses the `just-the-docs` theme, and these links are defined through `aux_links` in `_config.yml`. However, the related styles for `aux-nav` were applied only inside a desktop-only media query (`min-width: 50rem`), which caused the buttons to be hidden on mobile.

---

### **What I changed**

* Moved the `aux-nav` styles outside the desktop-only media query
* Kept layout-specific styling (like extra padding) limited to larger screens
* Ensured Dark Mode and GitHub links show up properly on mobile devices

---

### **Why this helps**

* Mobile users can now access Dark Mode and the GitHub repo easily
* Navigation behavior is consistent across screen sizes
* No changes to the existing desktop experience

---

### **Testing**

* Checked the site locally on both mobile and desktop views
* Confirmed that both buttons are visible and functional on mobile

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reorganized navigation and auxiliary-nav styling for more consistent layout and behavior across breakpoints
  * Added desktop-specific spacing tweaks and responsive adjustments to improve header/nav appearance
  * Consolidated button and icon styling within the nav context for visual consistency
  * Introduced quiz-related color and styling updates
  * Cleaned up legacy styles for simpler, more maintainable presentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->