### PR TITLE
update footer copyright year from 2025 to 2026

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -80,7 +80,7 @@ aux_links:
 
 # Footer content 
 # appears at the bottom of every page's main content
-footer_content: "Copyright &copy; 2025 Contributors to CircuitVerse. Distributed under a [CC-by-sa] license."
+footer_content: "Copyright &copy; 2026 Contributors to CircuitVerse. Distributed under a [CC-by-sa] license."
 
 # Footer last edited timestamp
 last_edit_timestamp: false # show or hide edit time - page must have `last_modified_date` defined in the frontmatter


### PR DESCRIPTION
<!-- Thank you for contributing to this repository, it is much appreciated! Make sure that you follow this template strictly.
Pull requests won't be merged if the template is not properly filled.
-->

Update footer copyright year to 2026

<!--
Use "Fixes" only when the pull request completely satisfies the issue.
Use "Ref" only when the pull request partially satisfies the issue.
-->
Fixes #751 

<!-- what all has been done in this pull request -->
#### Changes done:
- [x] Updated the footer configuration to change the copyright year from **2025** to **2026**
- [x] Synced footer year with the current year to avoid outdated information

<!-- Any UI or styling change needs screenshots -->
#### Screenshots
Not applicable (text-only configuration change)

<!-- Preview links of all the files that have been changed/updated -->
#### Preview Link(s):
- [_config.yml](https://github.com/himanshujays29/Interactive-Book/blob/fix/update-footer-year-2026/_config.yml)

<!-- Before creating a PR, make sure to verify the following. -->
#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Sample preview link added (config-only change)
- [x] Tried squashing the commits into one


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year in footer from 2025 to 2026.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->