### PR TITLE
Feature: Lock quiz after first answer and show correct option (#740)

### DIFF
--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -58,9 +58,26 @@ $(function() {
 });
 
 function ShowQuizAnswer(element) {
-    if (!$(element).hasClass('quiz-show-answer')) {
-        $(element).addClass('quiz-show-answer');
+    var $element = $(element);
+    var $question = $element.closest('.quiz-question');
+
+    // Prevent multiple selections
+    if ($question.data('locked')) return;
+    $question.data('locked', true);
+
+    // Show selected answer
+    $element.addClass('quiz-show-answer');
+
+    // If wrong, show correct one
+    if ($element.hasClass('quiz-false')) {
+        $question.find('.quiz-true').addClass('quiz-show-answer');
     }
+
+    // Disable all answers
+    $question.find('.quiz-answer').each(function () {
+        this.onclick = null;
+        $(this).css('pointer-events', 'none');
+    });
 }
 
 function FilterHtml(contents) {


### PR DESCRIPTION
Fixes #740 

#### Changes done:
- [x] Locked quiz after first answer selection
- [x] Disabled all other options after selection
- [x] Automatically highlighted correct answer when a wrong option is chosen

#### Screenshots
After fix:
- Only one selection allowed
- Correct answer highlighted automatically
<img width="1919" height="908" alt="Quiz after fix" src="https://github.com/user-attachments/assets/a2b60e33-f5fb-4bbb-aa54-44b0955da18f" />

<!-- Preview links of all the files that have been changed/updated -->
#### Preview Link(s): 
(To be added after checks complete)

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Sample preview link added
- [x] Tried squashing the commits into one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevents multiple answer selections per question
  * Visually highlights selected answers
  * Reveals correct answer when an incorrect choice is made
  * Locks questions after selection to prevent changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->