### PR TITLE
Fixed typos in Docs

### DIFF
--- a/docs/binary-algebra/ieee-std-754.md
+++ b/docs/binary-algebra/ieee-std-754.md
@@ -21,7 +21,7 @@ has_children: false
 
 ## Representing real numbers
 
-While the representation of integer quantities using binary numbers is straightforward, representation of real numbers and its arithmetics require special care. See Section 3.11 in {% cite donzellini2018introduction --file books %}
+While the representation of integer quantities using binary numbers is straightforward, representation of real numbers and its arithmetic require special care. See Section 3.11 in {% cite donzellini2018introduction --file books %}
 
 
 ### Fixed point
@@ -40,7 +40,7 @@ A part of the binary number is used to store the *significand* (including a sign
 
 ## The IEEE 754 Standard
 
-There are multiple ways of implementenig floating point numbers and arithmetics. However, since 1985 the IEEE Standard for Floating-Point Arithmetic (IEEE 754) has been available addressing many issues and providing a reliable and portable definition.
+There are multiple ways of implementenig floating point numbers and arithmetic. However, since 1985 the IEEE Standard for Floating-Point Arithmetic (IEEE 754) has been available addressing many issues and providing a reliable and portable definition.
 
 The latest version of the standard was published in 2019 {% cite ieee754std2019 --file books %} and the latest ISO version (identical to the IEEE Std 754) was published in 2020 {% cite iso60559 --file books %}
 

--- a/docs/binary-algebra/ieee-std-754.md
+++ b/docs/binary-algebra/ieee-std-754.md
@@ -40,7 +40,7 @@ A part of the binary number is used to store the *significand* (including a sign
 
 ## The IEEE 754 Standard
 
-There are multiple ways of implementenig floating point numbers and arithmetic. However, since 1985 the IEEE Standard for Floating-Point Arithmetic (IEEE 754) has been available addressing many issues and providing a reliable and portable definition.
+There are multiple ways of implementing floating point numbers and arithmetic. However, since 1985 the IEEE Standard for Floating-Point Arithmetic (IEEE 754) has been available addressing many issues and providing a reliable and portable definition.
 
 The latest version of the standard was published in 2019 {% cite ieee754std2019 --file books %} and the latest ISO version (identical to the IEEE Std 754) was published in 2020 {% cite iso60559 --file books %}
 

--- a/docs/binary-representation/binary-numbers.md
+++ b/docs/binary-representation/binary-numbers.md
@@ -21,7 +21,7 @@ has_children: false
 
 ## Introduction
 
-Binary number system was invented by **Gottfried Leibniz**. As the word is prefixed with 'Bi' which is a Latin word and means 'two' in English. This brings us to the first two digits i.e., 0 and 1 which means that while counting in binary you cannot exceed 1. Infact all the numbers which you represent are made up of only two digits i.e., 0 and 1 which is quite interesting. Check out the binary representation of a decimal number (the numbers used for counting i.e., from 0-9) in binary.
+Binary number system was invented by **Gottfried Leibniz**. As the word is prefixed with 'Bi' which is a Latin word and means 'two' in English. This brings us to the first two digits i.e., 0 and 1 which means that while counting in binary you cannot exceed 1. In fact all the numbers which you represent are made up of only two digits i.e., 0 and 1 which is quite interesting. Check out the binary representation of a decimal number (the numbers used for counting i.e., from 0-9) in binary.
 
 ```yaml
 Example:

--- a/docs/binary-representation/binary-numbers.md
+++ b/docs/binary-representation/binary-numbers.md
@@ -21,7 +21,7 @@ has_children: false
 
 ## Introduction
 
-Binary number system was invented by **Gottfried Leibniz**. As the word is prefixed with 'Bi' which is a Latin word and means 'two' in English. This brings us to the first two digits i.e., 0 and 1 which means that while counting in binary you cannot exceed 1. In fact all the numbers which you represent are made up of only two digits i.e., 0 and 1 which is quite interesting. Check out the binary representation of a decimal number (the numbers used for counting i.e., from 0-9) in binary.
+Binary number system was invented by **Gottfried Leibniz**. As the word is prefixed with 'Bi' which is a Latin word and means 'two' in English. This brings us to the first two digits i.e., 0 and 1 which means that while counting in binary you cannot exceed 1. In fact, all the numbers which you represent are made up of only two digits i.e., 0 and 1 which is quite interesting. Check out the binary representation of a decimal number (the numbers used for counting i.e., from 0-9) in binary.
 
 ```yaml
 Example:

--- a/docs/binary-representation/discrete-quantities.md
+++ b/docs/binary-representation/discrete-quantities.md
@@ -23,7 +23,7 @@ has_children: false
 
 -   Section 1.1 "Analog and Discrete Variables" in {% cite donzellini2018introduction --file books %}
 -   Section "Analogue and digital data" (Chapter 1) in {% cite stonham2017digital --file books %}
--   Secion "Digital and analogue signals" (Chapter 1) in {% cite morris2013digital --file books %}
+-   Section "Digital and analogue signals" (Chapter 1) in {% cite morris2013digital --file books %}
 -   Chapter 1 "Introduction: Analog Versus Digital" in {% cite lameres2019introduction --file books %}
 
 

--- a/docs/binary-representation/negative-quantities.md
+++ b/docs/binary-representation/negative-quantities.md
@@ -74,7 +74,7 @@ add 1               +           1
 	* -149
 	1. +17
 
-2.  The greatest negative number which can be stored in a 8-bit register using 2's complement arithemtic is ?
+2.  The greatest negative number which can be stored in a 8-bit register using 2's complement arithmetic is ?
 	* -256
 	* -255
 	1. -128

--- a/docs/binary-representation/negative-quantities.md
+++ b/docs/binary-representation/negative-quantities.md
@@ -74,7 +74,7 @@ add 1               +           1
 	* -149
 	1. +17
 
-2.  The greatest negative number which can be stored in a 8-bit register using 2's complement arithmetic is ?
+2.  The greatest negative number which can be stored in an 8-bit register using 2's complement arithmetic is ?
 	* -256
 	* -255
 	1. -128

--- a/docs/comb-lsi/alu.md
+++ b/docs/comb-lsi/alu.md
@@ -48,7 +48,7 @@ There are a few important takeaways here:
 - These Instructions can used to create meaningful programs. Since these are required to be easily available, they can be stored on ROM unit.
 - The input arguments A and B are often stored in Internal Registers. These along with other special purpose register form the registers of the microcontroller.
 - ROM memories are slower in speed, hence an intermediate high speed RAM is often used.
-- All the critical timings, decoding of the instructions are often grouped together in seperate control and timings unit.
+- All the critical timings, decoding of the instructions are often grouped together in separate control and timings unit.
 - If a Micro controller would be constructed only from ALU, RAM and ROM, there would not be any external interface. Hence, you now have Input/Output (I/O) ports.
 - Additional features such as Interrupts, communication protocols, EEPROM, Timers/Counters, Debug interfaces etc. are incorporated to make a controller complete.
 

--- a/docs/comb-msi/adders.md
+++ b/docs/comb-msi/adders.md
@@ -198,7 +198,7 @@ If A > B Cout = 0 and the result of binary form (A-B) then Cout = 1 and the resu
 	* Full Adder
 
 5. In which of the following cases Adders can be used as a primary element ?
-	1. Arithmatic Logic Unit (ALU)
+	1. Arithmetic Logic Unit (ALU)
 	1. Digital Calculator
 	* Memory Block
 	* Loop Operation

--- a/docs/comb-msi/mux-demux.md
+++ b/docs/comb-msi/mux-demux.md
@@ -179,7 +179,7 @@ A 1 : 16 demultiplexer can be implemented using **two** 1 : 8 demultiplexers.
    * Coder
    *  Both MUX & DEMUX
 
-2. Which of the following logic block has a number of input lines and one signle output line ?
+2. Which of the following logic block has a number of input lines and one single output line ?
 
    * Decoder
    1. Multiplexer

--- a/docs/logic-design/mev.md
+++ b/docs/logic-design/mev.md
@@ -75,7 +75,7 @@ A method of MEV minimization based on partial variables is described in:
 -   Section "Minimizing MEV maps" in {% cite stonham2017digital --file books %}
 -   Section "Map-entered variables" in {% cite kohavi2010switching --file books %}
 
-Another recursive method which can be used when the MEV only has expessions of one variable (or its complement) is described next.
+Another recursive method which can be used when the MEV only has expressions of one variable (or its complement) is described next.
 
 The expressions found in the map's cells can have these forms:
 

--- a/docs/seq-design/flow-diagrams.md
+++ b/docs/seq-design/flow-diagrams.md
@@ -40,7 +40,7 @@ An extension to the flowchart diagram which includes timing information is known
 More information about ASM charts can be found in:
 
 -   Section 7.2 "ASM Diagrams" in {% cite donzellini2018introduction --file books %}
--   Section "Algoritmic state machines" (Chapter 5) in {% cite stonham2017digital --file books %}
+-   Section "Algorithmic state machines" (Chapter 5) in {% cite stonham2017digital --file books %}
 -   *ASM++* Project webpage at the Universidad de Valladolid [ASM++: a modern Algorithmic State Machine methodology for RTL designs](http://www.epyme.uva.es/asm++/)
 
 

--- a/docs/seq-design/fsm.md
+++ b/docs/seq-design/fsm.md
@@ -76,7 +76,7 @@ In this module, you will learn how to use a Final-State-Machine(FSM) which descr
 ## Problem
 Assume, you have a soda vending machine which sells soda cans of cost 15¢ each, and you have only 2 types of coins: 10¢ and 5¢.
 
-In this problem, our goal is to make a state machine which can determine, how much change should be returned, and when a can is dispenced.
+In this problem, our goal is to make a state machine which can determine, how much change should be returned, and when a can is dispensed.
 ```
 Note: In this design, ignore the capacity of the stock, which means, we’ll assume that there will always be can in the vending machine.
 Also, you can assume that only one action could be made in every “clock cycle” or state.

--- a/docs/seq-design/mds.md
+++ b/docs/seq-design/mds.md
@@ -42,5 +42,5 @@ For complex digital logic system with a large number of inputs, the following de
     3.  Draw detailed block diagram
 5.  Draw MDS diagram
 6.  Choose the controller architecture: SSI (logic gates and flip-flops), MSI (based on MUXs, &#x2026;) or LSI (ROM based, &#x2026;)
-7.  Asign state codes
+7.  Assign state codes
 8.  Implement the circuit based on the design

--- a/docs/seq-design/seq-synth.md
+++ b/docs/seq-design/seq-synth.md
@@ -23,7 +23,7 @@ has_children: false
 
 ## Introduction
 
-As presented in section [FSM]({% link docs/seq-design/fsm.md %}) any sequential circuit can be modelled using Finite State Machines (FSM) or, viceversa, any FSM can be implemented in a sequential circuit.
+As presented in section [FSM]({% link docs/seq-design/fsm.md %}) any sequential circuit can be modelled using Finite State Machines (FSM) or, vice-versa, any FSM can be implemented in a sequential circuit.
 
 The process to obtain such a circuit from its functional description or model is referred to as *sequential synthesis*.
 
@@ -36,7 +36,7 @@ Every sequential circuit can also be represented by the following general model:
 
 The first step in the synthesis process is to state the *functional description* of the system in terms of a FSM. The state machine can be formally represented by state diagrams or state tables.
 
-The number of state variables $(r)$ is directly related to the number of states which can represented by those state variables $(2^r)$. Also, the number of components or their size is related to the number of state variables. On the other hand, the devised FSM might contain redundant states. Therefore, in order to obtain an optimal circuit (in terms of the number of components and number of feedback connections) it is desirable to reduce the number of states by eliminating unnecesary ones. This is the second step in the process.
+The number of state variables $(r)$ is directly related to the number of states which can represented by those state variables $(2^r)$. Also, the number of components or their size is related to the number of state variables. On the other hand, the devised FSM might contain redundant states. Therefore, in order to obtain an optimal circuit (in terms of the number of components and number of feedback connections) it is desirable to reduce the number of states by eliminating unnecessary ones. This is the second step in the process.
 
 To represent the state with the binary state variables, a binary code must be assigned to each state. A careful selection of the state codes can help in a later stage to minimise the number of components in the combinational logic block.
 

--- a/docs/seq-msi/registers.md
+++ b/docs/seq-msi/registers.md
@@ -27,7 +27,7 @@ To increase the storage capacity in terms of number of bits, you can use a group
 The n-bit register will consist of n number of flip-flop(s) and it is capable of storing an n-bit word.
 
 
-The binary-data, in a register, can be transfered within itself from one flip-flop to another. 
+The binary-data, in a register, can be transferred within itself from one flip-flop to another. 
 A shift register is a type of register that allows such data transfers.
 Shift register has 4 modes of operations.
 


### PR DESCRIPTION
Fix typos in documentation and contribution guidelines

#### Changes done:
- [x] Corrected spelling and grammar mistakes in `contributing_guidelines.org`  
- [x] Fixed typos across multiple markdown files in the `docs/` directory  
- [x] Cleaned up minor formatting inconsistencies

#### Screenshots  
Not applicable (text-only changes)

#### Preview Link(s):  
N/A

#### ✅️ By submitting this PR, I have verified the following
- [x] Checked to see if a similar PR has already been opened 🤔️  
- [x] Reviewed the contributing guidelines 🔍️  
- [ ] Sample preview link added (not applicable)  
- [x] Tried squashing the commits into one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected numerous typos, spelling, punctuation, and hyphenation issues across guides and tutorials.
  * Improved terminology and phrasing for standards, algorithms, and design descriptions for clarity and consistency.
  * Fixed wording in quizzes, problem statements, and instructional steps to reduce ambiguity.
  * Minor editorial tweaks to headings and references for a more polished reading experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->