### PR TITLE
Fix MathJax rendering in ROM microcontroller quiz options (closes #759)

### DIFF
--- a/docs/seq-lsi/rom-microcontrollers.md
+++ b/docs/seq-lsi/rom-microcontrollers.md
@@ -68,10 +68,10 @@ ROM capacity: $2^N \times (2N+K+\log_2 M)$
 {:.quiz}
 
 1. What is the ROM capacity of Counter based µcontroller ?
-   1. 2^N\times(K+\log_2 M)
-   * 2^N\times(N+K+\log_2 M)
-   * 2^{(M+N)}\times(K+N)
-   * 2^M\times(M+N)
+   1. $2^N \times (K+\log_2 M)$
+   * $2^N \times (N+K+\log_2 M)$
+   * $2^{(M+N)} \times (K+N)$
+   * $2^M \times (M+N)$
 
 2. Which among the following is not micro-controller ?
    1. DMUX based µcontroller
@@ -80,7 +80,7 @@ ROM capacity: $2^N \times (2N+K+\log_2 M)$
    * None
 
 3. What is the ROM capacity of Preset counter based µcontroller ?
-   1. 2^N\times(N+K+\log_2 M)
-   * 2^N\times(K+\log_2 M)
-   * 2^{(M+N)}\times(K+N)
-   * 2^M\times(M+N)
+   1. $2^N \times (N+K+\log_2 M)$
+   * $2^N \times (K+\log_2 M)$
+   * $2^{(M+N)} \times (K+N)$
+   * $2^M \times (M+N)$


### PR DESCRIPTION
The two ROM-capacity quiz questions in `docs/seq-lsi/rom-microcontrollers.md` had their math options written without `$...$` wrappers, so MathJax left them as raw `\times` / `\log_2` text (see screenshot in #759).

Wrapped each option in `$...$` to match the convention used a few lines above in the same file (e.g. line 39 `ROM capacity: $2^N \times (K+\log_2 M)$`). Answer positions (the `1.` marker) are unchanged, and question 2 (no math) is untouched.

Closes #759.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the visual formatting of multiple-choice quiz questions in the ROM microcontroller documentation, with improved math expression rendering for better readability and consistency across quiz answer options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CircuitVerse/Interactive-Book/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->